### PR TITLE
Fix redis events outbound transit

### DIFF
--- a/redis_events/docker/integration.yml
+++ b/redis_events/docker/integration.yml
@@ -21,5 +21,8 @@ wallet-key: "test-wallet-key"
 
 no-ledger: true
 
+debug-connections: true
 auto-accept-invites: true
 auto-respond-messages: true
+
+log-level: info

--- a/redis_events/integration/docker-compose.yml
+++ b/redis_events/integration/docker-compose.yml
@@ -160,6 +160,9 @@ services:
         '/wait && python -m redis_events.v1_0.services.deliverer.deliver "$@"',
         "--",
       ]
+    extra_hosts:
+      - "alice:host-gateway"
+      - "faber:host-gateway"
 
   faber:
     image: plugin-image
@@ -170,19 +173,22 @@ services:
         - install_flags=--no-interaction --with integration
     ports:
       - 3001:3001
+      - 3000:3000
     depends_on:
       - redis-cluster
       - relay
       - deliverer
-    command: start --arg-file integration.yml -e http://faber:3000 --label faber --log-level debug
+    command: start --arg-file integration.yml --label faber
     environment:
       - WAIT_BEFORE_HOSTS=10
-      - WAIT_HOSTS=redis-node-3:6379, relay:8071, relay:8081
+      - WAIT_HOSTS=redis-node-3:6379, relay:8071
       - WAIT_HOSTS_TIMEOUT=120
       - WAIT_SLEEP_INTERVAL=1
       - WAIT_HOST_CONNECT_TIMEOUT=60
     networks:
       - acapy_default
+    extra_hosts:
+      - "alice:host-gateway"
 
   alice:
     image: plugin-image
@@ -191,9 +197,14 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration
-    command: start -it http 0.0.0.0 3000 -ot http -e http://alice:3000 --auto-accept-invites --auto-respond-messages --admin 0.0.0.0 3001 --admin-insecure-mode --label alice --no-ledger --log-level debug
+    ports:
+      - 8021:8021
+      - 8020:8020
+    command: start -it http 0.0.0.0 8020 -ot http -e http://alice:8020 --auto-accept-invites --auto-respond-messages --admin 0.0.0.0 8021 --admin-insecure-mode --label alice --no-ledger --log-level debug --debug-connections
     networks:
       - acapy_default
+    extra_hosts:
+      - "relay:host-gateway"
 
   tests:
     container_name: juggernaut
@@ -201,8 +212,8 @@ services:
       context: .
       dockerfile: Dockerfile.test.runner
     environment:
-      - WAIT_BEFORE_HOSTS=10
-      - WAIT_HOSTS=faber:3001, alice:3000
+      - WAIT_BEFORE_HOSTS=15
+      - WAIT_HOSTS=faber:3001, alice:8020, relay:8071
       - WAIT_HOSTS_TIMEOUT=60
       - WAIT_SLEEP_INTERVAL=1
       - WAIT_HOST_CONNECT_TIMEOUT=30
@@ -212,6 +223,10 @@ services:
       - alice
     networks:
       - acapy_default
+    extra_hosts:
+      - "faber:host-gateway"
+      - "relay:host-gateway"
+      - "alice:host-gateway"
 
 networks:
   acapy_default:

--- a/redis_events/integration/tests/test_events.py
+++ b/redis_events/integration/tests/test_events.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from . import FABER, ALICE, RELAY, Agent, post
+from . import FABER, ALICE, RELAY, Agent
 
 
 @pytest.fixture(scope="session")

--- a/redis_events/redis_events/v1_0/redis_queue/events/__init__.py
+++ b/redis_events/redis_events/v1_0/redis_queue/events/__init__.py
@@ -22,6 +22,7 @@ LOGGER = logging.getLogger(__name__)
 
 async def setup(context: InjectionContext):
     """Setup the plugin."""
+    LOGGER.info("> plugin setup...")
     config = get_config(context.settings).event or EventConfig.default()
 
     bus = context.inject(EventBus)
@@ -34,6 +35,7 @@ async def setup(context: InjectionContext):
 
     bus.subscribe(STARTUP_EVENT_PATTERN, on_startup)
     bus.subscribe(SHUTDOWN_EVENT_PATTERN, on_shutdown)
+    LOGGER.info("< plugin setup.")
 
 
 RECORD_RE = re.compile(r"acapy::record::([^:]*)(?:::(.*))?")

--- a/redis_events/redis_events/v1_0/redis_queue/outbound.py
+++ b/redis_events/redis_events/v1_0/redis_queue/outbound.py
@@ -36,11 +36,11 @@ class RedisOutboundQueue(BaseOutboundTransport):
 
     def __init__(
         self,
-        wire_format: BaseWireFormat,
-        root_profile: Profile,
+        root_profile,
+        **kwargs,
     ):
         """Initialize base queue type."""
-        super().__init__(root_profile, wire_format)
+        super().__init__(**kwargs)
         self.outbound_config = (
             get_config(root_profile.context.settings).outbound
             or OutboundConfig.default()

--- a/redis_events/redis_events/v1_0/redis_queue/outbound.py
+++ b/redis_events/redis_events/v1_0/redis_queue/outbound.py
@@ -4,7 +4,6 @@ import json
 
 import logging
 
-from aries_cloudagent.transport.wire_format import BaseWireFormat
 from aries_cloudagent.core.profile import Profile
 from aries_cloudagent.transport.outbound.base import (
     BaseOutboundTransport,

--- a/redis_events/redis_events/v1_0/redis_queue/tests/test_outbound.py
+++ b/redis_events/redis_events/v1_0/redis_queue/tests/test_outbound.py
@@ -1,22 +1,22 @@
 import base64
 import datetime
-import redis
-import time
 import json
+import time
 
-from aries_cloudagent.core.in_memory import InMemoryProfile
-from aries_cloudagent.transport.wire_format import BaseWireFormat
-from aries_cloudagent.transport.outbound.base import (
-    QueuedOutboundMessage,
-    OutboundMessage,
-    ConnectionTarget,
-)
+import redis
 from aiohttp.test_utils import unused_port
-from asynctest import TestCase as AsyncTestCase, mock as async_mock, PropertyMock
+from aries_cloudagent.core.in_memory import InMemoryProfile
+from aries_cloudagent.transport.outbound.base import (ConnectionTarget,
+                                                      OutboundMessage,
+                                                      QueuedOutboundMessage)
+from aries_cloudagent.transport.wire_format import BaseWireFormat
+from asynctest import PropertyMock
+from asynctest import TestCase as AsyncTestCase
+from asynctest import mock as async_mock
 
+from .. import config as test_config
 from .. import outbound as test_outbound
 from .. import utils as test_util
-from .. import config as test_config
 from ..outbound import RedisOutboundQueue
 
 SETTINGS = {
@@ -340,9 +340,7 @@ class TestRedisOutbound(AsyncTestCase):
             async_mock.MagicMock(),
         )
         wire_format = BaseWireFormat()
-        redis_outbound_inst = RedisOutboundQueue(
-            root_profile=self.profile, wire_format=wire_format
-        )
+        redis_outbound_inst = RedisOutboundQueue(self.profile)
         q_out_msg = QueuedOutboundMessage(
             profile=self.profile,
             message=OutboundMessage(payload="test-message"),
@@ -391,9 +389,8 @@ class TestRedisOutbound(AsyncTestCase):
                 )
             ),
         ):
-            wire_format = BaseWireFormat()
             redis_outbound_inst = RedisOutboundQueue(
-                root_profile=self.profile, wire_format=wire_format
+                root_profile=self.profile
             )
             q_out_msg = QueuedOutboundMessage(
                 profile=self.profile,
@@ -438,9 +435,8 @@ class TestRedisOutbound(AsyncTestCase):
                 )
             ),
         ):
-            wire_format = BaseWireFormat()
             redis_outbound_inst = RedisOutboundQueue(
-                root_profile=self.profile, wire_format=wire_format
+                root_profile=self.profile
             )
             q_out_msg = QueuedOutboundMessage(
                 profile=self.profile,


### PR DESCRIPTION
After getting more familiar with the plugin and how to test it I realized that the outbound transit wasn't working. It was related to child RedisOutboundQueue class having a `wire_format` parameter that caused a an error in acapy `aries_cloudagent/transport/outbound/manager.py` --> `TypeError: __init__() missing 1 required positional argument: 'wire_format'`.

I fixed it by copying the http outbound transit in acapy. After which I could see connections becoming `active` and the relay and deliverer services working correctly. I still think this would benefit from more testing of some of the use cases but now at least all the services are tested correctly.