### PR TITLE
chore: add dco remediation configuration

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+allowRemediationCommits:
+  individual: true
+  thirdParty: true


### PR DESCRIPTION
To help get #38 merged in, this configuration enables allowing 3rd party remediation commits.