### PR TITLE
Return redis_events tests

### DIFF
--- a/.github/workflows/pr-integration-tests.yaml
+++ b/.github/workflows/pr-integration-tests.yaml
@@ -1,7 +1,7 @@
 name: Integration Tests
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "**"
   push:

--- a/.github/workflows/pr-linting-and-unit-tests.yaml
+++ b/.github/workflows/pr-linting-and-unit-tests.yaml
@@ -1,7 +1,7 @@
 name: Linting and Unit Tests
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "**"
   push:

--- a/redis_events/docker/docker-compose.yml
+++ b/redis_events/docker/docker-compose.yml
@@ -123,7 +123,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        '/wait && python -m redis_events.v1_0.services.relay.relay "$@"',
+        '/wait && python -m redis_events.v1_0.services.relay.relay "$$@"',
         "--",
       ]
 
@@ -153,7 +153,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        '/wait && python -m redis_events.v1_0.services.deliverer.deliver "$@"',
+        '/wait && python -m redis_events.v1_0.services.deliverer.deliver "$$@"',
         "--",
       ]
 

--- a/redis_events/docker/integration.yml
+++ b/redis_events/docker/integration.yml
@@ -13,7 +13,7 @@ endpoint:
 
 plugin:
   - redis_events.v1_0.redis_queue.events
-  # - basicmessage_storage.v1_0
+  - basicmessage_storage.v1_0
 
 plugin-config: plugins-config.yml
 

--- a/redis_events/integration/Dockerfile
+++ b/redis_events/integration/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"
 
-# RUN pip install git+https://github.com/hyperledger/aries-acapy-plugins@main#subdirectory=basicmessage_storage
+RUN pip install git+https://github.com/hyperledger/aries-acapy-plugins@main#subdirectory=basicmessage_storage
 
 COPY redis_events/ redis_events/
 COPY docker/*.yml ./

--- a/redis_events/integration/README.md
+++ b/redis_events/integration/README.md
@@ -1,10 +1,10 @@
 # Integration Tests
 
-All plugins should have a suite of integration tests. We use `docker compose` to set up the environment, and make use of the [Dockerfile](../docker/Dockerfile) to produce our ACA-Py/Plugin image. To simplify, we have another [Dockerfile](Dockerfile.test.runner) for running those [tests](/tests/).
+We use `docker compose` to set up the environment, and make use of the main dockefile in the docker directory [Dockerfile](../docker/Dockerfile), and a similar dockerfile in integration driectory [Dockerfile](../integration/Dockerfile), which has an additional plugin basic_messages. This is used to persist message history for better testing. To simplify, we have another [Dockerfile](Dockerfile.test.runner) for running those [tests](/tests/).
 
 ## Build and run Tests
 
-The integration tests will start 2 agents - bob and alice - and a juggernaut container that will execute the tests. Test results will be found in the juggernaut container output. The juggernaut container should close itself down, the logs can be reviewed in the `Docker` view, open `Containers`, open `integration`, right-click the `integration-tests` container and select `View Logs`
+The integration tests will start 2 agents - faber and alice - and a juggernaut container that will execute the tests. Test results will be found in the juggernaut container output. The juggernaut container should close itself down, the logs can be reviewed in the `Docker` view, open `Containers`, open `integration`, right-click the `integration-tests` container and select `View Logs`
 
 ```sh
 # open a terminal in vs code

--- a/redis_events/integration/docker-compose.yml
+++ b/redis_events/integration/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        '/wait && python -m redis_events.v1_0.services.relay.relay "$@"',
+        '/wait && python -m redis_events.v1_0.services.relay.relay "$$@"',
         "--",
       ]
 
@@ -157,7 +157,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        '/wait && python -m redis_events.v1_0.services.deliverer.deliver "$@"',
+        '/wait && python -m redis_events.v1_0.services.deliverer.deliver "$$@"',
         "--",
       ]
     extra_hosts:

--- a/redis_events/integration/docker-compose.yml
+++ b/redis_events/integration/docker-compose.yml
@@ -165,7 +165,7 @@ services:
       - "faber:host-gateway"
 
   faber:
-    image: plugin-image
+    image: redis-events-integration
     build:
       context: ..
       dockerfile: integration/Dockerfile
@@ -191,7 +191,7 @@ services:
       - "alice:host-gateway"
 
   alice:
-    image: plugin-image
+    image: redis-events
     build:
       context: ..
       dockerfile: docker/Dockerfile

--- a/redis_events/integration/tests/test_events.py
+++ b/redis_events/integration/tests/test_events.py
@@ -75,9 +75,9 @@ async def test_outbound_queue_removes_messages_from_queue_and_deliver_sends_them
             retry_pop_count = retry_pop_count + 1
             time.sleep(1)
         msg_received = True
-    # messages = faber.retrieve_basicmessages()['results']
-    # assert "Hello Alice" in (msg['content'] for msg in messages)
-    # assert "Another Alice" in (msg['content'] for msg in messages)
+    messages = faber.retrieve_basicmessages()['results']
+    assert "Hello Alice" in (msg['content'] for msg in messages)
+    assert "Another Alice" in (msg['content'] for msg in messages)
 
 
 @pytest.mark.asyncio
@@ -97,11 +97,11 @@ async def test_deliverer_pulls_messages_from_queue_and_sends_them(
     )
 
     time.sleep(5)
-    # messages = faber.retrieve_basicmessages()['results']
-    # matching_msgs = [
-    #     msg for msg in messages if msg['content'] == "test-msg"]
-    # assert matching_msgs.__len__() == 2  # 1 for sent, 1 for received
-    # assert await redis.lrange("acapy_outbound", 0, -1) == []
+    messages = faber.retrieve_basicmessages()['results']
+    matching_msgs = [
+        msg for msg in messages if msg['content'] == "test-msg"]
+    assert matching_msgs.__len__() == 2  # 1 for sent, 1 for received
+    assert await redis.lrange("acapy_outbound", 0, -1) == []
 
 
 @pytest.mark.asyncio
@@ -145,5 +145,5 @@ async def test_deliverer_retry_on_failure(
             time.sleep(1)
         msg_received = True
 
-    # assert "test-failed-msg" in (msg['content']
-    #                              for msg in faber.retrieve_basicmessages()['results'])
+    assert "test-failed-msg" in (msg['content']
+                                 for msg in faber.retrieve_basicmessages()['results'])


### PR DESCRIPTION
Bring back the redis_events integration tests that use additional plugin after repairing the build backend config line that was missing.

Also: changed the integration image names so faber using the integration dockerfile with the additional plugin is different from alice using the normal dockerfile in the docker directory.
Also: removed the `edit` condition for the PR workflow. It's not needed. 
Also: Had to add additional `$` character on the docker compose startup command on my linux machine. Not sure why? The workflow machine works with or without it.