### PR TITLE
Normalize poetry versions in devcontainers/docker to match lockfiles

### DIFF
--- a/basicmessage_storage/.devcontainer/Dockerfile
+++ b/basicmessage_storage/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.9-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-ARG POETRY_VERSION="1.4.2"
+ARG POETRY_VERSION="1.7.1"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 

--- a/basicmessage_storage/.devcontainer/devcontainer.json
+++ b/basicmessage_storage/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "context": "..",
     "args": {
       "VARIANT": "3.9-bullseye",
-      "POETRY_VERSION": "1.4.2"
+      "POETRY_VERSION": "1.7.1"
     }
   },
   "customizations": {

--- a/basicmessage_storage/docker/Dockerfile
+++ b/basicmessage_storage/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -

--- a/connection_update/.devcontainer/Dockerfile
+++ b/connection_update/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.9-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-ARG POETRY_VERSION="1.4.2"
+ARG POETRY_VERSION="1.7.1"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 

--- a/connection_update/.devcontainer/devcontainer.json
+++ b/connection_update/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "context": "..",
     "args": {
       "VARIANT": "3.9-bullseye",
-      "POETRY_VERSION": "1.4.2"
+      "POETRY_VERSION": "1.7.1"
     }
   },
   "customizations": {

--- a/connection_update/docker/Dockerfile
+++ b/connection_update/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -

--- a/kafka_events/.devcontainer/Dockerfile
+++ b/kafka_events/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.9-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-ARG POETRY_VERSION="1.4.2"
+ARG POETRY_VERSION="1.7.1"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 

--- a/kafka_events/.devcontainer/devcontainer.json
+++ b/kafka_events/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
       "context": "..",
       "args": {
         "VARIANT": "3.9-bullseye",
-        "POETRY_VERSION": "1.4.2"
+        "POETRY_VERSION": "1.7.1"
       }
     },
     "customizations": {

--- a/multitenant_provider/.devcontainer/Dockerfile
+++ b/multitenant_provider/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.9-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-ARG POETRY_VERSION="1.4.2"
+ARG POETRY_VERSION="1.7.1"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 

--- a/multitenant_provider/.devcontainer/devcontainer.json
+++ b/multitenant_provider/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "context": "..",
     "args": {
       "VARIANT": "3.9-bullseye",
-      "POETRY_VERSION": "1.4.2"
+      "POETRY_VERSION": "1.7.1"
     }
   },
   "customizations": {

--- a/multitenant_provider/docker/Dockerfile
+++ b/multitenant_provider/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -

--- a/oid4vci/.devcontainer/Dockerfile
+++ b/oid4vci/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.9-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-ARG POETRY_VERSION="1.4.2"
+ARG POETRY_VERSION="1.7.1"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 

--- a/oid4vci/.devcontainer/devcontainer.json
+++ b/oid4vci/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "context": "..",
     "args": {
       "VARIANT": "3.9-bullseye",
-      "POETRY_VERSION": "1.4.2"
+      "POETRY_VERSION": "1.7.1"
     }
   },
   "customizations": {

--- a/oid4vci/docker/Dockerfile
+++ b/oid4vci/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl jq && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -

--- a/plugin_globals/.devcontainer/Dockerfile
+++ b/plugin_globals/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.9-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-ARG POETRY_VERSION="1.4.2"
+ARG POETRY_VERSION="1.7.1"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 

--- a/plugin_globals/.devcontainer/devcontainer.json
+++ b/plugin_globals/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "context": "..",
     "args": {
       "VARIANT": "3.9-bullseye",
-      "POETRY_VERSION": "1.4.2"
+      "POETRY_VERSION": "1.7.1"
     }
   },
   "customizations": {

--- a/plugin_globals/docker/Dockerfile
+++ b/plugin_globals/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -

--- a/redis_events/.devcontainer/Dockerfile
+++ b/redis_events/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="3.9-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-ARG POETRY_VERSION="1.4.2"
+ARG POETRY_VERSION="1.7.1"
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VERSION=${POETRY_VERSION}
 

--- a/redis_events/.devcontainer/devcontainer.json
+++ b/redis_events/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "context": "..",
     "args": {
       "VARIANT": "3.9-bullseye",
-      "POETRY_VERSION": "1.4.2"
+      "POETRY_VERSION": "1.7.1"
     }
   },
   "customizations": {

--- a/redis_events/docker/Dockerfile
+++ b/redis_events/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -

--- a/redis_events/docker/services/Dockerfile
+++ b/redis_events/docker/services/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -

--- a/redis_events/integration/Dockerfile
+++ b/redis_events/integration/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Install and configure poetry
 USER root
 
-ENV POETRY_VERSION=1.4.2
+ENV POETRY_VERSION=1.7.1
 ENV POETRY_HOME=/opt/poetry
 RUN apt-get update && apt-get install -y curl && apt-get clean
 RUN curl -sSL https://install.python-poetry.org | python -


### PR DESCRIPTION
The `poetry.lock` files have been generated by 1.7.1 for the plugins, but looks like the devcontainers and dokerfiles reference Poetry 1.4.2.

This PR sets them all to the matching 1.7.1

ACA-Py actually uses 1.6.1 so maybe that would be more appropriate, but ACA-Py should probably update to a newer version with 0.12.0 (?) or a subsequent release. Also it probably doesn't matter to have the slight mismatch between these plugins and ACA-Py for Poetry version
https://github.com/hyperledger/aries-cloudagent-python/blob/main/poetry.lock