### PR TITLE
Fix outbound queue with webhook-url

### DIFF
--- a/redis_events/docker/integration.yml
+++ b/redis_events/docker/integration.yml
@@ -26,3 +26,5 @@ auto-accept-invites: true
 auto-respond-messages: true
 
 log-level: info
+
+webhook-url: http://dummy-server:8080

--- a/redis_events/docker/plugins-config.yml
+++ b/redis_events/docker/plugins-config.yml
@@ -29,6 +29,16 @@ redis_queue:
       acapy::revocation-notification::received: acapy-revocation-notification-received
       acapy::revocation-notification-v2::received: acapy-revocation-notification-v2-received
       acapy::forward::received: acapy-forward-received
+    event_webhook_topic_maps:
+      acapy::basicmessage::received: basicmessages
+      acapy::problem_report: problem_report
+      acapy::ping::received: ping
+      acapy::ping::response_received: ping
+      acapy::actionmenu::received: actionmenu
+      acapy::actionmenu::get-active-menu: get-active-menu
+      acapy::actionmenu::perform-menu-action: perform-menu-action
+      acapy::keylist::updated: keylist
+      acapy::record::connections::active: acapy-record-connections-active
     deliver_webhook: true
 
 

--- a/redis_events/integration/docker-compose.yml
+++ b/redis_events/integration/docker-compose.yml
@@ -164,6 +164,14 @@ services:
       - "alice:host-gateway"
       - "faber:host-gateway"
 
+  dummy-server:
+    image: python:3.9-slim
+    ports:
+      - 8080:8080
+    command: python -m http.server 8080
+    networks:
+      - acapy_default
+
   faber:
     image: redis-events-integration
     build:
@@ -221,12 +229,14 @@ services:
       - redis-cluster
       - faber
       - alice
+      - dummy-server
     networks:
       - acapy_default
     extra_hosts:
       - "faber:host-gateway"
       - "relay:host-gateway"
       - "alice:host-gateway"
+      - "dummy-server:host-gateway"
 
 networks:
   acapy_default:

--- a/redis_events/integration/tests/test_events.py
+++ b/redis_events/integration/tests/test_events.py
@@ -65,16 +65,6 @@ async def test_base_redis_keys_are_set(redis):
 async def test_outbound_queue_removes_messages_from_queue_and_deliver_sends_them(faber: Agent, established_connection: str, redis):
     faber.send_message(established_connection, "Hello Alice")
     faber.send_message(established_connection, "Another Alice")
-    msg_received = False
-    retry_pop_count = 0
-    while not msg_received:
-        msg = await redis.blpop("acapy_outbound", 2)
-        if not msg:
-            if retry_pop_count > 3:
-                raise Exception("blpop call failed to retrieve message")
-            retry_pop_count = retry_pop_count + 1
-            time.sleep(1)
-        msg_received = True
     messages = faber.retrieve_basicmessages()['results']
     assert "Hello Alice" in (msg['content'] for msg in messages)
     assert "Another Alice" in (msg['content'] for msg in messages)


### PR DESCRIPTION
This fixes a bug where an empty header value was added to the outbound payload which caused the outbound transit to fail. Also, ignore webhook forwarding for messages which don't match the webhook event map.

Added a available dummy server to the integration test network and enabled the webhook url config in the integration tests.

I still don't understand why pushing an invalid outbound message into the queue is actually blocking/breaking the queue from continuing to work. This is a problem, as this small one line mistake, caused the invalid payload. I'll be trying to figure out how to prevent this, but this is still a fix/improvement for the current problem. 

@jpnortherblock