### PR TITLE
Bugfix: user pin should be retrieved from form data.

### DIFF
--- a/oid4vci/oid4vci/public_routes.py
+++ b/oid4vci/oid4vci/public_routes.py
@@ -116,7 +116,7 @@ async def token(request: web.Request):
     if not pre_authorized_code or not isinstance(pre_authorized_code, str):
         raise web.HTTPBadRequest(reason="pre-authorized_code is missing or invalid")
 
-    user_pin = request.query.get("user_pin")
+    user_pin = form.get("user_pin")
     try:
         async with context.profile.session() as session:
             record = await OID4VCIExchangeRecord.retrieve_by_code(


### PR DESCRIPTION
[OID4VCI]
At the token request, the user PIN should be retrieved from form data, similar to the grant type and pre-authorized code, rather than from query parameters.