### PR TITLE
:construction_worker: Configure dependabot to manage pip dependencies for each plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
- # For details on how this file works refer to:
- #   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# For details on how this file works refer to:
+#   - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions
@@ -11,4 +11,52 @@ updates:
       interval: weekly
     groups:
       all-actions:
-        patterns: [ "*" ]
+        patterns: ["*"]
+
+  # Maintain pip dependencies for basicmessage_storage plugin
+  - package-ecosystem: pip
+    directory: /basicmessage_storage
+    schedule:
+      interval: daily
+
+  # Maintain pip dependencies for connection_update plugin
+  - package-ecosystem: pip
+    directory: /connection_update
+    schedule:
+      interval: daily
+
+  # Maintain pip dependencies for kafka_events plugin
+  - package-ecosystem: pip
+    directory: /kafka_events
+    schedule:
+      interval: daily
+
+  # Maintain pip dependencies for multitenant_provider plugin
+  - package-ecosystem: pip
+    directory: /multitenant_provider
+    schedule:
+      interval: daily
+
+  # Maintain pip dependencies for oid4vci plugin
+  - package-ecosystem: pip
+    directory: /oid4vci
+    schedule:
+      interval: daily
+
+  # Maintain pip dependencies for plugin_globals
+  - package-ecosystem: pip
+    directory: /plugin_globals
+    schedule:
+      interval: daily
+
+  # Maintain pip dependencies for redis_events plugin
+  - package-ecosystem: pip
+    directory: /redis_events
+    schedule:
+      interval: daily
+
+  # Maintain pip dependencies for rpc plugin
+  - package-ecosystem: pip
+    directory: /rpc
+    schedule:
+      interval: daily


### PR DESCRIPTION
I notice that the dependabot file only manages github-actions

It makes sense to start defining pip dependency management for each plugin.

This PR just adds daily interval scheduling for each plugin.

This _will_ spam with a lot of new dependabot PRs initially, but I think that's good to get out of the way and start having an automated workflow for dependency management.

___

_**Note**_: this may increase the urgency of more frequent tagged releases. Currently this repo has no tagged releases. This means developers installing from this repo can only point to main, commit hashes, or will have to manage their own fork. 

No tagged releases makes version control harder, and developers pointing to main may get problems if they run an older ACA-Py instance which is not in the automated test workflows. e.g. if the tests run on ACA-Py 0.11, then tests may pass when it causes a dependency conflict in ACA-Py 0.10.

So, if this new dependabot workflow is merged, together with the future dependabot updates, it should probably come with an improved release cycle.

I propose daily releases ... when there are new changes. Which can probably be automated to just publish a tag with that day's date. That way there's better version control for people using these plugins. If something breaks for those pointing to main, they can easily point to an older tag. Not sure what alternative is best, considering each individual plugin will have its own development and update cycle.

These PRs can also be scheduled to come weekly, and then there are weekly releases?

Let me know what you think!