### PR TITLE
chore: enable merge group for checks

### DIFF
--- a/.github/workflows/pr-integration-tests.yaml
+++ b/.github/workflows/pr-integration-tests.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 jobs:
   integration-tests:

--- a/.github/workflows/pr-linting-and-unit-tests.yaml
+++ b/.github/workflows/pr-linting-and-unit-tests.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 
 jobs:
   linting-and-unit-tests:


### PR DESCRIPTION
To get a handle on the dependabot PRs open on this repo, I'm experimenting with introducing a merge queue. This change will enable the merge queue to know which checks to run to make sure a branch is ready to merge.