### PR TITLE
fix: adapt tunnel usage to new ngrok version

### DIFF
--- a/oid4vci/README.md
+++ b/oid4vci/README.md
@@ -12,12 +12,16 @@ This repository showcases a simplified demonstration of the OID4VCI (OpenID for 
 
 - Sphereon Wallet App on your mobile device
 - Docker + Docker Compose
+- Ngrok Account (free tier is okay)
 
 ### Steps to Run the Demo
+
+First, you'll have to get your authtoken from ngrok. Note this value down.
 
 ```shell
 cd oid4vci/demo
 docker compose build
+echo "NGROK_AUTHTOKEN=<PASTE YOUR AUTHTOKEN HERE>" > .env
 docker compose up
 docker compose down -v  # Clean up
 ```

--- a/oid4vci/demo/docker-compose.yaml
+++ b/oid4vci/demo/docker-compose.yaml
@@ -63,6 +63,8 @@ services:
     hostname: ngrok
     ports:
       - "4040:4040"
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
     command: ["http", "issuer:8081"]
     healthcheck:
       test: /bin/bash -c "</dev/tcp/ngrok/4040"

--- a/oid4vci/docker/entrypoint.sh
+++ b/oid4vci/docker/entrypoint.sh
@@ -7,7 +7,7 @@ WAIT_ATTEMPTS=${WAIT_ATTEMPTS:-10}
 
 liveliness_check () {
         for CURRENT_ATTEMPT in $(seq 1 "$WAIT_ATTEMPTS"); do
-                if ! curl -s -o /dev/null -w '%{http_code}' "${1}/status" | grep "200" > /dev/null; then
+                if ! curl -s -o /dev/null -w '%{http_code}' "${1}/api/tunnels/command_line" | grep "200" > /dev/null; then
 			if [[ $CURRENT_ATTEMPT -gt $WAIT_ATTEMPTS ]]
 			then
 				echo "Failed while waiting for 200 status from ${1}"


### PR DESCRIPTION
Ngrok now requires an account to create and use a tunnel. This change accounts for this by adding some instructions and making it possible to pass an authtoken to the ngrok container.