### PR TITLE
update release PR workflow token

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -360,7 +360,7 @@ jobs:
         with:
           author: Release Bot <release-bot@users.noreply.github.com>
           committer: Release Bot <release-bot@users.noreply.github.com>
-          token: ${{ secrets.BOT_PR_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Release v${{ steps.prepare_pr.outputs.tag_version }} Upgrades"
           title: "Release for aries-cloudagent v${{ steps.prepare_pr.outputs.tag_version }}"
           body: "${{ steps.prepare_pr.outputs.pr_body }}"

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -12,13 +12,12 @@ on:
     - cron: "0 0 * * *"
 
 
-permissions:
-  contents: write
-
 jobs:
   checks:
     name: "Create Release PR"
-    permissions: write-all
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       current_available_version: ${{ steps.current_available_version.outputs.version }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -5,14 +5,11 @@ on:
     branches: ['main']
     paths: ['*/poetry.lock']
 
-permissions:
-  contents: write
-
 jobs:
-
   checks:
     name: "Create Release"
-    permissions: write-all
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       should_create_release: ${{ steps.should_create_release.outputs.should_create_release }}


### PR DESCRIPTION
I tried using the new PAT token for the PR workflow but it didn't work. I'm thinking it possibly has the permissions required to make the release but not the PR. The normal GITHUB_TOKEN should have the permissions to make the PR so i'm trying that.

![Screenshot from 2024-05-14 08-29-27](https://github.com/hyperledger/aries-acapy-plugins/assets/31809382/4605bbb9-cb29-4a9e-81b8-a55edae41262)
