### PR TITLE
OID4VCI plugin - Fix delete  exchange-supported records

### DIFF
--- a/oid4vci/oid4vci/public_routes.py
+++ b/oid4vci/oid4vci/public_routes.py
@@ -350,7 +350,7 @@ async def issue_cred(request: web.Request):
     if not pop.holder_kid:
         raise web.HTTPBadRequest(reason="No kid in proof; required for jwt_vc_json")
     
-    #note: some wallets require that the "jti" and "id" are a uri - i.e. Animo Paradym wallet
+    #note: some wallets require that the "jti" and "id" are a uri -i.e. Animo Paradym wallet
     payload = {
         "vc": {
             **(supported.vc_additional_data or {}),

--- a/oid4vci/oid4vci/public_routes.py
+++ b/oid4vci/oid4vci/public_routes.py
@@ -350,7 +350,7 @@ async def issue_cred(request: web.Request):
     if not pop.holder_kid:
         raise web.HTTPBadRequest(reason="No kid in proof; required for jwt_vc_json")
     
-    #note: some wallets require that the "jti" and "id" are a uri -i.e. Animo Paradym wallet
+    #note: Some wallets require that the "jti" and "id" are a uri
     payload = {
         "vc": {
             **(supported.vc_additional_data or {}),

--- a/oid4vci/oid4vci/public_routes.py
+++ b/oid4vci/oid4vci/public_routes.py
@@ -350,7 +350,7 @@ async def issue_cred(request: web.Request):
     if not pop.holder_kid:
         raise web.HTTPBadRequest(reason="No kid in proof; required for jwt_vc_json")
     
-    #note: some wallets require that the "jti" and "id" are a uri - i.e. Paradym wallet
+    #note: some wallets require that the "jti" and "id" are a uri - i.e. Animo Paradym wallet
     payload = {
         "vc": {
             **(supported.vc_additional_data or {}),

--- a/oid4vci/oid4vci/public_routes.py
+++ b/oid4vci/oid4vci/public_routes.py
@@ -349,7 +349,8 @@ async def issue_cred(request: web.Request):
 
     if not pop.holder_kid:
         raise web.HTTPBadRequest(reason="No kid in proof; required for jwt_vc_json")
-
+    
+    #note: some wallets require that the "jti" and "id" are a uri - i.e. Paradym wallet
     payload = {
         "vc": {
             **(supported.vc_additional_data or {}),

--- a/oid4vci/oid4vci/public_routes.py
+++ b/oid4vci/oid4vci/public_routes.py
@@ -350,7 +350,7 @@ async def issue_cred(request: web.Request):
     if not pop.holder_kid:
         raise web.HTTPBadRequest(reason="No kid in proof; required for jwt_vc_json")
     
-    #note: some wallets require that the "jti" and "id" are a uri -i.e. Animo Paradym wallet
+    #note: some wallets require that the "jti" and "id" are a uri - i.e. Animo Paradym wallet
     payload = {
         "vc": {
             **(supported.vc_additional_data or {}),

--- a/oid4vci/oid4vci/routes.py
+++ b/oid4vci/oid4vci/routes.py
@@ -523,7 +523,7 @@ async def register(app: web.Application):
                 allow_head=False,
             ),
             web.delete(
-                "/oid4vci/exchange-supported/records/{cred_sup_id}",
+                "/oid4vci/exchange-supported/records/{supported_cred_id}",
                 supported_credential_remove,
             ),
         ]


### PR DESCRIPTION
Quick fix on ./oid4vci/exchange-supported/records delete. There is a typo that duplicates the "credential supported identifier" as a parameter causing deletes to fail.

FYI @dbluhm 