### PR TITLE
Fix logic for release workflows

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -75,7 +75,7 @@ jobs:
       #       Re-Release Check
       #----------------------------------------------
       - name: Re-Release Check
-        if: ${{ github.event.inputs.re_release == 'true' }}
+        if: github.event.inputs.re_release == 'true'
         run: |
           echo "Re-Release manually requested. Skipping upgrade available check."
       #----------------------------------------------
@@ -83,7 +83,8 @@ jobs:
       #       If the global version is greater than or equal to the remote version, exit
       #----------------------------------------------
       - name: Check if aries-cloudagent upgrade available
-        if: ${{ github.event.inputs.re_release != 'true' }}
+        id: upgrade_available
+        if: github.event.inputs.re_release != 'true'
         run: |
           current_available_version="${{steps.current_available_version.outputs.current_available_version}}"
           echo "Remote version = $current_available_version"
@@ -99,11 +100,13 @@ jobs:
             echo "Version of aries-cloudagent is up to date"
             exit 0
           fi
+            echo available=true >> $GITHUB_OUTPUT
             echo "Detected aries-cloudagent upgrade available..."
       #----------------------------------------------
       #       Update global aries-cloudagent version in lock file
       #----------------------------------------------
       - name: Update global acapy version
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         run: |
           python repo_manager.py 3
           echo "Update global acapy version"
@@ -111,6 +114,7 @@ jobs:
       #       Update all plugins with aries-cloudagent and global and local dependencies
       #----------------------------------------------
       - name: Run global updates
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         run: |
           python repo_manager.py 2
           echo "Upgrade all plugins"
@@ -118,6 +122,7 @@ jobs:
       #       Get all potential upgrades
       #----------------------------------------------
       - name: Get all potential upgrades
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         id: all_potential_upgrades
         run: |
           declare -a potential_upgrades=()
@@ -147,6 +152,7 @@ jobs:
       #----------------------------------------------
       - name: Lint plugins
         id: lint_plugins
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         continue-on-error: true
         run: |
           declare -a failed_plugins=()
@@ -171,6 +177,7 @@ jobs:
       #----------------------------------------------
       - name: Unit Test Plugins
         id: unit_test_plugins
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         continue-on-error: true
         run: |
           declare -a failed_plugins=()
@@ -194,11 +201,13 @@ jobs:
       #       Install docker compose
       # ----------------------------------------------
       - name: Initialize Docker Compose
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         uses: isbang/compose-action@v1.5.1
       # ----------------------------------------------
       #       Collect plugins that fail integration tests
       # ----------------------------------------------
       - name: Integration Test Plugins
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         id: integration_test_plugins
         continue-on-error: true
         run: |
@@ -234,6 +243,7 @@ jobs:
       # ----------------------------------------------
       - name: Prepare Pull Request 
         id: prepare_pr
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         run: |
           echo "Merging failed plugins"
           failed_plugins=()
@@ -355,6 +365,7 @@ jobs:
       #       Create Release PR
       #----------------------------------------------
       - name: Create PR
+        if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         uses: peter-evans/create-pull-request@v6
         with:
           author: Release Bot <release-bot@users.noreply.github.com>

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -12,6 +12,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     outputs:
+      current_global_version: ${{ steps.current_global_version.outputs.version }}
       should_create_release: ${{ steps.should_create_release.outputs.should_create_release }}
       body: ${{ steps.prepare_release.outputs.body }}
       tag: ${{ steps.prepare_release.outputs.tag }}
@@ -28,6 +29,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
+      #----------------------------------------------
+      #       Check the latest version from plugins_global lock file
+      #----------------------------------------------
+      - name: Get global aries-cloudagent version from plugins repo
+        id: current_global_version
+        run: |
+          cd plugin_globals
+          lock_version=$(grep -A1 'name = "aries-cloudagent"' poetry.lock | grep -v 'name = "aries-cloudagent"')
+          version=$(grep -oP '(?<=").*?(?=")' <<< "$lock_version")
+          echo current_global_version=$version >> $GITHUB_OUTPUT
+          echo "Global version = $version"
       # ----------------------------------------------
       #       Check if a release should be created
       # ----------------------------------------------
@@ -45,14 +57,22 @@ jobs:
           # Check if any of the changed files are poetry.lock files
           # and if they not match the global poetry.lock file
 
+          # Compare versions
+          current_global_version="${{steps.current_global_version.outputs.current_global_version}}"
+          sem_version () { 
+            echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; 
+          }
+
           for file in ${get_changed_files}; do
             if [[ $file == *"/poetry.lock"* ]] && [[ $file != *"integration/poetry.lock"* ]]; then
-              for plugin in ${upgraded_plugins}; do
-                if [[ $file == *"$plugin"* ]]; then
-                  echo "Upgrade Detected for $plugin in file $file"
-                  found_upgrade=true
-                fi
-              done
+              lock_version=$(grep -A1 'name = "aries-cloudagent"' $file | grep -v 'name = "aries-cloudagent"')
+              version=$(grep -oP '(?<=").*?(?=")' <<< "$lock_version")
+              echo "Version = $version"
+              echo "Global Version = $current_global_version"
+              if [[ $(sem_version $current_global_version) -ge $(sem_version $version) ]]; then
+                echo "Upgrade Detected for $plugin in file $file"
+                found_upgrade=true
+              fi
             fi
           done
 


### PR DESCRIPTION
I thought I tested this really good but there was a couple mistakes. 

The exit 0 in release_pr workflow wasn't exiting. I think changing the permissions broke this. I just added a condition for the remaining workflows instead of trying to force exit.

I had some bad logic in the release workflow. I don't know when I messed this up, but it was supposed to check that any lock files that were merged had been on an older version of aca-py. It was actually just checking if any lock files had changed :/

This fixes both those problems.  