### PR TITLE
Fix the release workflow upgrade check

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -64,14 +64,18 @@ jobs:
           }
 
           for file in ${get_changed_files}; do
-            if [[ $file == *"/poetry.lock"* ]] && [[ $file != *"integration/poetry.lock"* ]]; then
-              lock_version=$(grep -A1 'name = "aries-cloudagent"' $file | grep -v 'name = "aries-cloudagent"')
-              version=$(grep -oP '(?<=").*?(?=")' <<< "$lock_version")
-              echo "Version = $version"
+            number_of_slashes=$(grep -o "/" <<< "$file" | wc -l)
+            # Check if the lock file is rooted
+            if [[ $file == *"/poetry.lock"* ]] && [[ "$number_of_slashes" == 1  ]]; then
+              changes="$(git diff ${{ github.event.before }} ${{ github.event.after }} $file)"
+              lock_version=$(echo "$changes" | grep -A1 'name = "aries-cloudagent"' | head -n 2 | tail -n 1 | awk '{print $3}' | tr -d '"')
+              echo "File = $file"
+              echo "Old Version = $lock_version"
               echo "Global Version = $current_global_version"
-              if [[ $(sem_version $current_global_version) -ge $(sem_version $version) ]]; then
-                echo "Upgrade Detected for $plugin in file $file"
+              if [[ "$lock_version" ]] && [[ $(sem_version $current_global_version) -gt $(sem_version $lock_version) ]]; then
+                echo "Upgrade Detected in $file"
                 found_upgrade=true
+                break
               fi
             fi
           done


### PR DESCRIPTION
I still had issues here :/

1. I needed to avoid all lock files that aren't rooted. Some plugins have embedded lock files I hadn't accounted for.
2. I still wasn't doing what I wanted to detect upgrades after merge to main. I needed to look at the diff and then the `aries-cloudagent` dependency. If it had been changed and the old version was older then the global version then this is when we should release.