### PR TITLE
Adjust create release workflow and release docs

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -187,7 +187,7 @@ jobs:
               continue
             fi
             cd $current_folder
-            poetry install --no-interaction --no-root --extras "aca-py"
+            poetry install --no-interaction --no-root --all-extras
             if poetry run pytest; then
               echo "plugin $current_folder passed unit test check"
             else
@@ -213,9 +213,24 @@ jobs:
         run: |
           trap 'echo "integration_test_exit_code=$?" >> "$GITHUB_OUTPUT"' EXIT
           declare -a failed_plugins=()
+
+          # lite plugins should be skipped during integration tests
+          readarray -t lite_plugin_array < lite_plugins
+
+          elementIn () {
+            local e match="$1"
+            shift
+            for e; do [[ "$e" == "$match" ]] && return 0; done
+            return 1
+          }
+
           for dir in ./*/; do
             current_folder=$(basename "$dir")
-            if [[ $current_folder == "plugin_globals" ]]; then
+            # Skip plugin_globals and lite plugins
+            if [[ "$current_folder" == "plugin_globals" ]] ; then
+              continue
+            fi
+            if elementIn "$current_folder" "${lite_plugin_array[@]}"; then
               continue
             fi
             cd $current_folder/integration
@@ -310,6 +325,10 @@ jobs:
           fi
 
           # Update the RELEASES.md file with the release notes
+          # Remove the Plugin Release Status heading
+          sed -i '/# Plugin Release Status/d' RELEASES.md 
+          # Add a marker for the insertion of the upgraded plugins section
+          body=$(printf '%s \n*' "${body}")
           echo "$body" | cat - RELEASES.md > temp && mv temp RELEASES.md
 
           # Check if there are any upgrades
@@ -333,25 +352,32 @@ jobs:
 
           # Update the release notes with the upgraded plugins. 
           # For replacing with the sed command we need to double escape the newline and tab characters.
-          details=$(printf '#### Plugins upgraded this release: \n\t - ')
-          double_escape_details=$(printf '#### Plugins upgraded this release: \\n\\t - ')
+          details=$(printf '\n### Plugins Upgraded For ACA-Py Release %s \n - ' "$release_version")
+          double_escape_details=$(printf '\\n### Plugins Upgraded For ACA-Py Release %s \\n - ' "$release_version")
 
-          # For replacing the first occurence of ' - ' with the details
+          # For replacing the first occurence of '*' with the details
           count=${#upgraded_plugins[*]}
           for i in $(seq 0 "$(("$count" - 2))" );
           do
-              details=$(printf '%s %s \n\t - ' "$details" "${upgraded_plugins[$i]}")
-              double_escape_details=$(printf '%s %s \\n\\t - ' "$double_escape_details" "${upgraded_plugins[$i]}")
+              details=$(printf '%s %s \n - ' "$details" "${upgraded_plugins[$i]}")
+              double_escape_details=$(printf '%s %s \\n - ' "$double_escape_details" "${upgraded_plugins[$i]}")
           done
           details=$(printf '%s %s \n' "$details" "${upgraded_plugins[$count - 1]}")
           double_escape_details=$(printf '%s %s \n' "$double_escape_details" "${upgraded_plugins[$count - 1]}")
 
-          # Replace the first occurence of ' - ' with the details
-          sed -i "0,/\s\-\s/s// - $(printf '%s ' ${double_escape_details})/" RELEASES.md
+          # Replace the first occurence of '*' with the details
+          sed -i "0,/*/s//$(printf '%s ' ${double_escape_details})/" RELEASES.md
 
           # Replace the release version with the release tag
           sed -i "0,/v$release_version/{s/v$release_version/v$tag_version/}" RELEASES.md
           body=${body/v$release_version/v$tag_version}
+
+          # Add the heading for the Plugin Release Status and RELEASES.md
+          heading="# Plugin Release Status"
+          # Remove the * insertion marker from the body
+          body=$(echo "$body" | sed 's/\*//g')
+          body=$(printf '%s\n%s' "${heading}" "${body}")
+          printf '%s\n%s\n' "${heading}" "$(cat RELEASES.md)" > RELEASES.md
 
           # Prepare the PR body
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -125,11 +125,11 @@ jobs:
           body=$(python repo_manager.py 4)
           body=${body/v$version/v$release_tag}
           upgraded_plugins=($(python repo_manager.py 5))
-          details=$(printf '#### Plugins upgraded this release: \n\t - ')
+          details=$(printf '### Plugins Upgraded For ACA-Py Release %s \n - ' '$version')
           count=${#upgraded_plugins[*]}
           for i in $(seq 0 "$(("$count" - 2))" );
           do
-              details=$(printf '%s %s \n\t - ' "$details" "${upgraded_plugins[$i]}")
+              details=$(printf '%s %s \n - ' "$details" "${upgraded_plugins[$i]}")
           done
           details=$(printf '%s %s \n' "$details" "${upgraded_plugins[$count - 1]}")
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,7 @@
-### Release v0.12.2
-##### The latest supported versions of aries-cloudagent for each plugin are as follows:
+# Plugin Release Status
+## ACA-Py Release 0.12.2
 
-| Plugin Name | Supported aries-cloudagent version |
+| Plugin Name | Supported ACA-Py Release |
 | --- | --- |
 |basicmessage_storage | 0.12.2|
 |connection_update | 0.12.2|
@@ -12,23 +12,23 @@
 |multitenant_provider | 0.12.2|
 |oid4vci | 0.12.2|
 |redis_events | 0.12.2|
-|rpc | 0.12.2|
-***
- - #### Plugins upgraded this release: 
-	 - basicmessage_storage 
-	 - connection_update 
-	 - firebase_push_notifications 
-	 - jwt_vc_json 
-	 - kafka_events 
-	 - mso_mdoc 
-	 - multitenant_provider 
-	 - oid4vci 
-	 - redis_events 
-	 - rpc 
-### Release v0.12.1
-##### The latest supported versions of aries-cloudagent for each plugin are as follows:
+|rpc | 0.12.2| 
 
-| Plugin Name | Supported aries-cloudagent version |
+### Plugins Upgraded For ACA-Py Release 0.12.2 
+ - basicmessage_storage 
+ - connection_update 
+ - firebase_push_notifications 
+ - jwt_vc_json 
+ - kafka_events 
+ - mso_mdoc 
+ - multitenant_provider 
+ - oid4vci 
+ - redis_events 
+ - rpc 
+
+## ACA-Py Release 0.12.1
+
+| Plugin Name | Supported ACA-Py Release |
 | --- | --- |
 |basicmessage_storage | 0.12.1|
 |connection_update | 0.12.1|
@@ -38,13 +38,14 @@
 |oid4vci | 0.12.1|
 |redis_events | 0.12.1|
 |rpc | 0.12.1|
-***
- - #### Plugins upgraded this release: 
-	 - basicmessage_storage 
-	 - connection_update 
-	 - firebase_push_notifications 
-	 - kafka_events 
-	 - multitenant_provider 
-	 - oid4vci 
-	 - redis_events 
-	 - rpc 
+
+### Plugins Upgraded For ACA-Py Release 0.12.1
+
+- basicmessage_storage
+- connection_update
+- firebase_push_notifications
+- kafka_events
+- multitenant_provider
+- oid4vci
+- redis_events
+- rpc

--- a/repo_manager.py
+++ b/repo_manager.py
@@ -404,10 +404,10 @@ def main(arg_1=None, arg_2=None):
                     global_version = re.findall(r'"([^"]*)"', next_line)
                     break
         # Create and output the markdown release notes
-        msg = f"""### Release v{global_version[0]}\n##### The latest supported versions of aries-cloudagent for each plugin are as follows:\n"""
+        msg = f"""## ACA-Py Release {global_version[0]}\n"""
         print(msg)
         # Markdown table header
-        print("| Plugin Name | Supported aries-cloudagent version |")
+        print("| Plugin Name | Supported ACA-Py Release |")
         print("| --- | --- |")
         for plugin_name in sorted(os.listdir("./")):
             if is_plugin_directory(plugin_name):
@@ -443,9 +443,8 @@ def main(arg_1=None, arg_2=None):
                 with open(f"./{plugin_name}/pyproject.toml", "w") as file:
                     file.write(filedata)
                 print(f"|{plugin_name} | {version[0]}|")
-
-        print("***")
-        print(" - ")
+        
+        print("\n")
 
     elif selection == "5":
         """
@@ -470,14 +469,14 @@ def main(arg_1=None, arg_2=None):
         with open("RELEASES.md", "r") as file:
             last_releases = []
             for line in file:
-                if f"### Release v{global_version[0]}" in line:
+                if f"## ACA-Py Release {global_version[0]}" in line:
                     line = next(file)
                     line = next(file)
                     line = next(file)
-                    while "***" not in line:
+                    while "### Plugins Upgraded" not in line:
                         if (
                             line
-                            != "| Plugin Name | Supported aries-cloudagent version |\n"
+                            != "| Plugin Name | Supported ACA-Py Release |\n"
                             and line != "| --- | --- |\n"
                         ):
                             last_releases.append(line.strip())
@@ -491,9 +490,12 @@ def main(arg_1=None, arg_2=None):
 
         # Get all released plugins and the plugins not on the global version
         for item in last_releases:
-            released_plugins.append(item.split("|")[1].strip())
-            if item.split("|")[2].strip() == global_version[0]:
-                plugins_on_old_release.append(item.split("|")[1].strip())
+            split_item = item.split("|")
+            if len(split_item) > 1:
+                released_plugins.append(split_item[1].strip())
+                
+                if split_item[2].strip() == global_version[0]:
+                    plugins_on_old_release.append(split_item[1].strip())
 
         # If there is releases in the RELEASES.md file then look for new plugins and add them to plugins on old release
         if last_releases:


### PR DESCRIPTION
This adjust the release pr workflow to produce better formatted release notes and does some additional improvements. Also ignores the lite plugins during the create release pr integration tests.

This automation is pretty unmaintainable do to all the bash script functions and text parsing. One way to improve the maintainability may be to write more of these bash script functions as python functions like it does for the repo_manager options 4 and 5.

I don't anticipate too many changes with this so I'm going to leave it as is for now and hope the commenting is enough for someone to handle in the future.