### PR TITLE
chore(hedera): Update Hiero DID SDK to 0.1.3

### DIFF
--- a/hedera/hedera/tests/did/test_resolver.py
+++ b/hedera/hedera/tests/did/test_resolver.py
@@ -10,31 +10,31 @@ class TestDidResolver:
     @patch("hedera.did.resolver.SdkHederaDidResolver")
     async def test_resolve_success(self, mock_hedera_did_resolver, profile, context):
         did = (
-            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574"
+            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749"
         )
         did_document = {
             "didDocumentMetadata": {
-                "versionId": "1734001354.326604",
-                "created": "2024-12-12",
-                "updated": "2024-12-12",
+                "created": "2025-11-24T13:35:39.177474Z",
+                "updated": "2025-11-24T13:35:39.177474Z",
+                "deactivated": False,
             },
             "didResolutionMetadata": {"contentType": "application/did+ld+json"},
             "didDocument": {
                 "@context": "https://www.w3.org/ns/did/v1",
-                "id": "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574",
+                "id": "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749",
                 "verificationMethod": [
                     {
-                        "id": "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574#did-root-key",
+                        "id": "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749#did-root-key",
                         "type": "Ed25519VerificationKey2018",
-                        "controller": "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574",
+                        "controller": "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749",
                         "publicKeyBase58": "HNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ",
                     }
                 ],
                 "assertionMethod": [
-                    "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574#did-root-key"
+                    "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749#did-root-key"
                 ],
                 "authentication": [
-                    "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574#did-root-key"
+                    "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749#did-root-key"
                 ],
             },
         }
@@ -89,7 +89,7 @@ class TestDidResolver:
         self, mock_hedera_did_resolver, profile, context
     ):
         did = (
-            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574"
+            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749"
         )
         did_document = {
             "didDocument": {
@@ -122,7 +122,7 @@ class TestDidResolver:
     @patch("hedera.did.resolver.SdkHederaDidResolver")
     async def test_resolve_no_medatada(self, mock_hedera_did_resolver, profile, context):
         did = (
-            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574"
+            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749"
         )
         did_document = {
             "didDocument": None,
@@ -144,7 +144,7 @@ class TestDidResolver:
         self, mock_hedera_did_resolver, profile, context
     ):
         did = (
-            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.5254574"
+            "did:hedera:testnet:zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ_0.0.7312749"
         )
         did_document = {
             "didDocument": None,

--- a/hedera/integration/tests/test_hedera_anoncreds_full_flow.py
+++ b/hedera/integration/tests/test_hedera_anoncreds_full_flow.py
@@ -170,7 +170,8 @@ class TestHederaAnonCredsFullFlow:
         )
         assert credential_definition_id
 
-        time.sleep(10)
+        # We want to wait a bit longer for revocation registry creation to reduce test flakiness
+        time.sleep(15)
 
         print("""
               +---------------------------------------------+

--- a/hedera/integration/tests/test_hedera_did.py
+++ b/hedera/integration/tests/test_hedera_did.py
@@ -44,7 +44,7 @@ class TestHederaDid:
         method = "hedera:testnet"
         ver_key = "zHNJ37tiLbGxD7XPvnTkaZCAV3PCe5P4HJFGMGUkVVZAJ"
         ver_key_no_multibase = ver_key[1:]
-        topic_id = "0.0.5254574"
+        topic_id = "0.0.7312749"
         did = f"did:{method}:{ver_key}_{topic_id}"
 
         holder.create_wallet(persist_token=True)
@@ -54,9 +54,9 @@ class TestHederaDid:
         assert response == {
             "did_document": {
                 "didDocumentMetadata": {
-                    "versionId": "1734001354.326603",
-                    "created": "2024-12-12",
-                    "updated": "2024-12-12",
+                    "created": "2025-11-24T13:35:39.177474Z",
+                    "updated": "2025-11-24T13:35:39.177474Z",
+                    "deactivated": False,
                 },
                 "didResolutionMetadata": {"contentType": "application/did+ld+json"},
                 "didDocument": {

--- a/hedera/poetry.lock
+++ b/hedera/poetry.lock
@@ -702,7 +702,6 @@ files = [
     {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb"},
     {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b"},
     {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543"},
-    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:60eb32934076fa07e4316b7b2742fa52cbb190b42c2df2863dbc4230a0a9b385"},
     {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e"},
     {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e"},
     {file = "cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053"},
@@ -713,7 +712,6 @@ files = [
     {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289"},
     {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7"},
     {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c"},
-    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9abcc2e083cbe8dde89124a47e5e53ec38751f0d7dfd36801008f316a127d7ba"},
     {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64"},
     {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285"},
     {file = "cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417"},
@@ -1335,14 +1333,14 @@ setuptools = "*"
 
 [[package]]
 name = "hiero-did-sdk-python"
-version = "0.1.1"
+version = "0.1.3"
 description = "The repository contains the Python SDK for managing DID Documents and Anoncreds Verifiable Credentials registry using Hedera Consensus Service."
 optional = false
 python-versions = "<4.0,>=3.12"
 groups = ["main"]
 files = [
-    {file = "hiero_did_sdk_python-0.1.1-py3-none-any.whl", hash = "sha256:3b04b68e1b36f82be372757be9e0776140b1b6baaabd468f3be853c66b550231"},
-    {file = "hiero_did_sdk_python-0.1.1.tar.gz", hash = "sha256:7f0d6c56135f3df26cdff6d32b9f4cd5d2176a9c01bd05239d205552d9e6f7bd"},
+    {file = "hiero_did_sdk_python-0.1.3-py3-none-any.whl", hash = "sha256:bf6d258c883106c801fde3270387878b9dbd70b6aabf34e2eb0f1f86fee912ea"},
+    {file = "hiero_did_sdk_python-0.1.3.tar.gz", hash = "sha256:5783e69c9168f2859abc2aae322b2546553a02d87d844878d944a6b331fd311f"},
 ]
 
 [package.dependencies]
@@ -1415,6 +1413,7 @@ python-versions = ">=3.6.3"
 groups = ["main", "integration"]
 files = [
     {file = "indy_vdr-0.4.2-py3-none-macosx_10_9_universal2.whl", hash = "sha256:21e4cc22bdb1de581e4abe00e2201d970f46e05d2420437fe023052614867553"},
+    {file = "indy_vdr-0.4.2-py3-none-macosx_14_0_universal2.whl", hash = "sha256:87c6ce352e87950e322c48341bd2d7e4e6899dd989484972ce24d20c761c6656"},
     {file = "indy_vdr-0.4.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:9dc8e16e8a0c4666c1a9f0a3e9967cb3dace92975b8dbb9b0aa2c7785ac5e12b"},
     {file = "indy_vdr-0.4.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:b1390ee6cbf47967c565b16b7b672969ee54485dd16963ecdd451dc128aff7c1"},
     {file = "indy_vdr-0.4.2-py3-none-win_amd64.whl", hash = "sha256:abb70e9dc46d59a6be1ac1a9b3530732c5dc8afe67f5aacba20bc7404c7d3317"},
@@ -3582,4 +3581,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "a88a301ea1f615149133406610db784916cd48abb193b63f06d16345cf73d6dc"
+content-hash = "6caa532919ea6122b9897f154a8099809940cff7a8fbe196ab2f923280fbadce"

--- a/hedera/pyproject.toml
+++ b/hedera/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.12"
 # explicitly installed with the plugin if desired.
 acapy-agent = { version = "~1.4.0", optional = true }
 
-hiero-did-sdk-python = "0.1.1"
+hiero-did-sdk-python = "0.1.3"
 
 [tool.poetry.extras]
 aca-py = ["acapy-agent"]


### PR DESCRIPTION
- Updated [Hiero DID SDK Python](https://github.com/hiero-ledger/hiero-did-sdk-python) to latest version
- Updated test cases to reflect changes in DID SDK + increased waiting time before checking for active Revocation Registry in AnonCreds flow integration test (should help with network-related intermittent failures)