### PR TITLE
Point refs to openwallet-foundation

### DIFF
--- a/issue_credential/poetry.lock
+++ b/issue_credential/poetry.lock
@@ -2124,16 +2124,16 @@ files = []
 develop = false
 
 [package.dependencies]
-issue-credential = {git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "issue_credential"}
+issue-credential = {git = "https://github.com/jamshale/acapy-plugins.git", branch = "python3.13-upgrade", subdirectory = "issue_credential"}
 
 [package.extras]
 aca-py = ["acapy-agent @ git+https://github.com/openwallet-foundation/acapy.git@main"]
 
 [package.source]
 type = "git"
-url = "https://github.com/jamshale/acapy-plugins.git"
-reference = "python3.13-upgrade"
-resolved_reference = "9ebd3a76524389c6364c700e09f936464cdca6cf"
+url = "https://github.com/openwallet-foundation/acapy-plugins.git"
+reference = "main"
+resolved_reference = "237f6e10eecc95be5d183f31e29bce063c4bfdcb"
 subdirectory = "present_proof"
 
 [[package]]
@@ -3386,4 +3386,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "f650bc34388e75371f7d7d6e3699caa666222ebec2e2e501357097c3c43a454a"
+content-hash = "dce1328d8fe2a368a425c33dccffcfb79ef27983c954f3b1d435abd9f64a3162"

--- a/issue_credential/pyproject.toml
+++ b/issue_credential/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.13"
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
 acapy-agent = { git = "https://github.com/openwallet-foundation/acapy.git", branch = "main", optional = true }
-present-proof = { git = "https://github.com/jamshale/acapy-plugins.git", branch = "python3.13-upgrade", subdirectory = "present_proof" }
+present-proof = { git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "present_proof" }
 
 
 [tool.poetry.extras]

--- a/present_proof/poetry.lock
+++ b/present_proof/poetry.lock
@@ -1504,16 +1504,16 @@ files = []
 develop = false
 
 [package.dependencies]
-present-proof = {git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "present_proof"}
+present-proof = {git = "https://github.com/jamshale/acapy-plugins.git", branch = "python3.13-upgrade", subdirectory = "present_proof"}
 
 [package.extras]
 aca-py = ["acapy-agent @ git+https://github.com/openwallet-foundation/acapy.git@main"]
 
 [package.source]
 type = "git"
-url = "https://github.com/jamshale/acapy-plugins.git"
-reference = "python3.13-upgrade"
-resolved_reference = "9ebd3a76524389c6364c700e09f936464cdca6cf"
+url = "https://github.com/openwallet-foundation/acapy-plugins.git"
+reference = "main"
+resolved_reference = "237f6e10eecc95be5d183f31e29bce063c4bfdcb"
 subdirectory = "issue_credential"
 
 [[package]]
@@ -3509,4 +3509,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "df3b1682ccfa85987e2f24497096444819237020b96b1d5b9d180136d7f804a1"
+content-hash = "ce55e99aeb8444c7cfa93949a0f7689edf93d43d3b782bcb800fb4f757ebd893"

--- a/present_proof/pyproject.toml
+++ b/present_proof/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.13"
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
 acapy-agent = { git = "https://github.com/openwallet-foundation/acapy.git", branch = "main", optional = true }
-issue-credential = { git = "https://github.com/jamshale/acapy-plugins.git", branch = "python3.13-upgrade", subdirectory = "issue_credential" }
+issue-credential = { git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "issue_credential" }
 
 
 [tool.poetry.extras]


### PR DESCRIPTION
Plugins that reference other plugins can have annoying dependency issues. I'll try and think of an easier way to manage them but this will be the last one for the python upgrade.