### PR TITLE
Release for acapy-agent 1.6.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,41 @@
 
 > **Note:** Release notes are also published as [GitHub Releases](https://github.com/openwallet-foundation/acapy-plugins/releases). This file may be phased out in favor of the CHANGELOG and release tags; feedback welcome.
 
+## ACA-Py Release 1.6.0
+
+| Plugin Name | Supported ACA-Py Release |
+| --- | --- |
+|basicmessage_storage | 1.6.0|
+|cache_redis | 1.6.0|
+|cheqd | 1.6.0|
+|connection_update | 1.6.0|
+|connections | 1.6.0|
+|issue_credential | 1.6.0|
+|firebase_push_notifications | 1.6.0|
+|hedera | 1.6.0|
+|multitenant_provider | 1.6.0|
+|oid4vc | 1.6.0|
+|present_proof | 1.6.0|
+|redis_events | 1.6.0|
+|rpc | 1.6.0|
+|status_list | 1.6.0|
+
+### Plugins Upgraded For ACA-Py Release 1.6.0
+ - basicmessage_storage
+ - cache_redis
+ - cheqd
+ - connection_update
+ - connections
+ - issue_credential
+ - firebase_push_notifications
+ - hedera
+ - multitenant_provider
+ - oid4vc
+ - present_proof
+ - redis_events
+ - rpc
+ - status_list
+
 ## ACA-Py Release 1.5.1
 
 | Plugin Name | Supported ACA-Py Release |

--- a/basicmessage_storage/poetry.lock
+++ b/basicmessage_storage/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1311,20 +1311,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -1917,19 +1913,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3113,4 +3096,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "b7920fdbadd5e266395c057aa77caddd046af194b03e8b913b94575159f89a56"
+content-hash = "e437d29e94919765bd68e2f540d50ff0e4aa18a1f58806c047f4c945652bc151"

--- a/basicmessage_storage/pyproject.toml
+++ b/basicmessage_storage/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "basicmessage_storage"
 version = "0.1.0"
-description = " (Supported acapy-agent version: 1.5.1) "
+description = " (Supported acapy-agent version: 1.6.0) "
 authors = ["Jason Sherman <tools@usingtechnolo.gy>"]
 
 [tool.poetry.dependencies]
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 mergedeep = "^1.3.4"
 

--- a/cache_redis/poetry.lock
+++ b/cache_redis/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1466,20 +1466,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2143,19 +2139,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3427,4 +3410,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "d6da7b837060bcd247f21bdde2f93f297a1dcb9c5d63b8a89478a4eec026eeaf"
+content-hash = "60b376236277f947cc14ff85c10d84908e4dfefd8faadd4aa632e41113d092ae"

--- a/cache_redis/pyproject.toml
+++ b/cache_redis/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "acapy-cache-redis"
 version = "0.1.0"
-description = "ACA-Py Cache Plugin for Redis enabling common cache on clustered deployments (Supported acapy-agent version: 1.5.1)"
+description = "ACA-Py Cache Plugin for Redis enabling common cache on clustered deployments (Supported acapy-agent version: 1.6.0)"
 authors = ["Colton Wolkins <colton@indicio.tech>", "Kim Ebert <kim@indicio.tech>", "Alex Walker <alex.walker@indicio.tech>"]
 
 [tool.poetry.dependencies]
 python = "^3.13"
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 redis = "^4.3.0"
 
 # Define ACA-Py as an optional/extra dependency so it can be

--- a/cheqd/poetry.lock
+++ b/cheqd/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1326,20 +1326,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -1920,19 +1916,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3116,4 +3099,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "24861d628222ccfd7f8e0cd614e5e68ba5f5d0c10dba1c14a9598bfd61ff53d6"
+content-hash = "c52fd32dfb7c9e52a92b1a6d448fa5c5cba828df556f1a1d39a33eb961f544c9"

--- a/cheqd/pyproject.toml
+++ b/cheqd/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cheqd"
 version = "0.1.0"
-description = " (Supported acapy-agent version: 1.5.1) "
+description = " (Supported acapy-agent version: 1.6.0) "
 authors = []
 
 [tool.poetry.dependencies]
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 cryptography = "<47.0.0"
 

--- a/connection_update/poetry.lock
+++ b/connection_update/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1311,20 +1311,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -1905,19 +1901,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3101,4 +3084,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "c19b13c99a01c703cbfb6f292d26ce12eb731a62c358e3ab628dff48db488864"
+content-hash = "48526765614163a82bc239f6335e73c64d70b230261b90ff6ae6854e64bd307b"

--- a/connection_update/pyproject.toml
+++ b/connection_update/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "connection_update"
 version = "0.1.0"
-description = " (Supported acapy-agent version: 1.5.1) "
+description = " (Supported acapy-agent version: 1.6.0) "
 authors = ["Jason Sherman <tools@usingtechnolo.gy>"]
 
 [tool.poetry.dependencies]
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 
 [tool.poetry.extras]

--- a/connections/poetry.lock
+++ b/connections/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1311,20 +1311,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -1905,19 +1901,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3101,4 +3084,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "c19b13c99a01c703cbfb6f292d26ce12eb731a62c358e3ab628dff48db488864"
+content-hash = "48526765614163a82bc239f6335e73c64d70b230261b90ff6ae6854e64bd307b"

--- a/connections/pyproject.toml
+++ b/connections/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 
 [tool.poetry.extras]

--- a/firebase_push_notifications/poetry.lock
+++ b/firebase_push_notifications/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1428,20 +1428,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2020,19 +2016,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3306,4 +3289,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "2b8daf1be5479e2bc225030e5dd8a80d2a431db0703ffc64b7d533d28d2796fb"
+content-hash = "157bf1fc03d2c76250498c0db2d942623a1ac915f75d71e431e449d3eb6a8b08"

--- a/firebase_push_notifications/pyproject.toml
+++ b/firebase_push_notifications/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "firebase_push_notifications"
 version = "0.1.0"
-description = " (Supported acapy-agent version: 1.5.1) "
+description = " (Supported acapy-agent version: 1.6.0) "
 authors = []
 
 [tool.poetry.dependencies]
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 marshmallow = "^3.23.3"
 google-auth = "^2.49.1"

--- a/hedera/poetry.lock
+++ b/hedera/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1471,20 +1471,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2079,19 +2075,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3595,4 +3578,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "4eb405aa09c1b28a51b76dac5fbc06e658d257592920fba1113cced317439125"
+content-hash = "6e1bb045d7600ca1e0b675a28924f8f622fd4d50d658aacca18a616c8018a4a7"

--- a/hedera/pyproject.toml
+++ b/hedera/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "hedera"
 version = "0.1.0"
-description = " (Supported acapy-agent version: 1.5.1) "
+description = " (Supported acapy-agent version: 1.6.0) "
 authors = []
 
 [tool.poetry.dependencies]
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 hiero-did-sdk-python = "0.1.6"
 

--- a/issue_credential/poetry.lock
+++ b/issue_credential/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1392,20 +1392,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2069,19 +2065,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3376,4 +3359,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "d31ecf644366df98a05bdc2f5fc268430fed1a2f584172ee3ab76ac0c8c297ad"
+content-hash = "83487c3382b853b23b6d1a678f03de3e8c3dc379bf9e6b18004dc577b84e0490"

--- a/issue_credential/pyproject.toml
+++ b/issue_credential/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 present-proof = { git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "present_proof" }
 
 

--- a/multitenant_provider/poetry.lock
+++ b/multitenant_provider/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1388,20 +1388,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -1994,19 +1990,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3188,4 +3171,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "e114ad2608e943a87785f05b543bf6bc273ad91a74a59a185a5ea6847d1433b6"
+content-hash = "414547dd32f80f656aa535245d30a336c6922d104c2b0dbbe1e9ed9611ad1292"

--- a/multitenant_provider/pyproject.toml
+++ b/multitenant_provider/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "multitenant_provider"
 version = "0.1.0"
-description = " (Supported acapy-agent version: 1.5.1) "
+description = " (Supported acapy-agent version: 1.6.0) "
 authors = ["Jason Sherman <tools@usingtechnolo.gy>"]
 
 [tool.poetry.dependencies]
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 bcrypt = "^5.0.0"
 mergedeep = "^1.3.4"

--- a/oid4vc/poetry.lock
+++ b/oid4vc/poetry.lock
@@ -2,17 +2,16 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
-develop = false
 
 [package.dependencies]
 aiohttp = ">=3.11.16,<3.14.0"
@@ -30,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -40,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -57,12 +56,6 @@ uuid_utils = ">=0.10,<0.15"
 bbs = ["ursa-bbs-signatures (>=1.0.1,<1.1.0)"]
 didcommv2 = ["didcomm-messaging (>=0.1.1a0,<0.2.0)"]
 sqlcipher = ["sqlcipher3-binary (>=0.5.4)"]
-
-[package.source]
-type = "git"
-url = "https://github.com/openwallet-foundation/acapy.git"
-reference = "main"
-resolved_reference = "d7527214a44103325ff5a0331f9a4003d37edeba"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1696,20 +1689,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jsonpointer"
@@ -2329,19 +2318,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3751,4 +3727,4 @@ sd-jwt-vc = ["jsonpointer"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "c4783e82c04700994d2ca0d732950136227daa645fb3e317a6bd31e6df2ddd73"
+content-hash = "ca8a655538de7c65e2b3c5ca3f5217d6ace930090f8e60db48e0c535ea69d35e"

--- a/oid4vc/pyproject.toml
+++ b/oid4vc/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "oid4vc"
 version = "0.1.0"
-description = "OpenID for Verifiable Credentials plugin for acapy. (Supported acapy-agent version: 1.5.1) "
+description = "OpenID for Verifiable Credentials plugin for acapy. (Supported acapy-agent version: 1.6.0) "
 authors = [
     "Adam Burdett <burdettadam@gmail.com>",
     "Char Howland <char@indicio.tech>",
@@ -22,7 +22,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 aiohttp = "^3.13.3"
 aries-askar = "~0.5.0"

--- a/plugin_globals/poetry.lock
+++ b/plugin_globals/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1311,20 +1311,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -1905,19 +1901,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3101,4 +3084,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "c19b13c99a01c703cbfb6f292d26ce12eb731a62c358e3ab628dff48db488864"
+content-hash = "48526765614163a82bc239f6335e73c64d70b230261b90ff6ae6854e64bd307b"

--- a/plugin_globals/pyproject.toml
+++ b/plugin_globals/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 
 [tool.poetry.extras]

--- a/present_proof/poetry.lock
+++ b/present_proof/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1541,20 +1541,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2218,19 +2214,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3499,4 +3482,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "664cf032e14e49152655ae0ba16cf5c7ccbfff7a3a225c57ace48341c401e57f"
+content-hash = "a82a1a9cfa4912be272d35022ce2e607ee43aa22bcc0a74a8093ab7f23bda35b"

--- a/present_proof/pyproject.toml
+++ b/present_proof/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 issue-credential = { git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "issue_credential" }
 
 

--- a/redis_events/poetry.lock
+++ b/redis_events/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1454,20 +1454,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2075,19 +2071,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3414,4 +3397,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "a733ff0b26e1682e050c0987d60a9ab7bfc54caf24e4b9b0a0a1c0398bd3cf9b"
+content-hash = "e05ce8a84133370ced162856bf9a5a1047a1903f6568a80ee155dd32f7ef322a"

--- a/redis_events/pyproject.toml
+++ b/redis_events/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 name = "redis_events"
 version = "0.1.0"
-description = "ACA-PY persisted events using Redis (Supported acapy-agent version: 1.5.1) "
+description = "ACA-PY persisted events using Redis (Supported acapy-agent version: 1.6.0) "
 
 [tool.poetry.dependencies]
 python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 aiohttp = "^3.13.3"
 fastapi-slim = "^0.128.0"

--- a/rpc/poetry.lock
+++ b/rpc/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1311,20 +1311,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -1905,19 +1901,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3101,4 +3084,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "c19b13c99a01c703cbfb6f292d26ce12eb731a62c358e3ab628dff48db488864"
+content-hash = "48526765614163a82bc239f6335e73c64d70b230261b90ff6ae6854e64bd307b"

--- a/rpc/pyproject.toml
+++ b/rpc/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "rpc"
 version = "0.1.0"
-description = " (Supported acapy-agent version: 1.5.1) "
+description = " (Supported acapy-agent version: 1.6.0) "
 authors = []
 
 [tool.poetry.dependencies]
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 
 [tool.poetry.extras]

--- a/status_list/poetry.lock
+++ b/status_list/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1467,20 +1467,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2061,19 +2057,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3257,4 +3240,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "aeff870770dbaf815cf0f37ee3119fb4f4838b5297355ccb1e830548ffd03add"
+content-hash = "c5e255a4673a5004a23b3acbbd39ff7f0321c97cbfb0d5f46cc1c8c37bb47e1f"

--- a/status_list/pyproject.toml
+++ b/status_list/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "status_list"
 version = "0.1.0"
-description = "Status List plugin for ACA-Py (Supported acapy-agent version: 1.5.1) "
+description = "Status List plugin for ACA-Py (Supported acapy-agent version: 1.6.0) "
 authors = ["Ivan Wei <ivan.wei@ontario.ca>"]
 readme = "README.md"
 
@@ -10,7 +10,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.5.1", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 bitarray = "^3.0.0"
 filelock = "^3.20.3"

--- a/webvh/poetry.lock
+++ b/webvh/poetry.lock
@@ -2,15 +2,15 @@
 
 [[package]]
 name = "acapy-agent"
-version = "1.5.1"
+version = "1.6.0"
 description = "(ACA-Py) A Cloud Agent Python is a foundation for building decentralized identity applications and services running in non-mobile environments. "
 optional = true
 python-versions = "<4.0,>=3.13"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "acapy_agent-1.5.1-py3-none-any.whl", hash = "sha256:fb091da05ee78a9ec583d5663ff6ec71dda4c6df0f0804f2b2feb6187bb0c819"},
-    {file = "acapy_agent-1.5.1.tar.gz", hash = "sha256:9e10678ddebad8d1d7760d0ccb51f8c033c3495e579a28a5a9913274d2227c34"},
+    {file = "acapy_agent-1.6.0-py3-none-any.whl", hash = "sha256:fb69b043e0b54d9e46fa2710637a5383045fb7b1b61f42df199d9014fa99878a"},
+    {file = "acapy_agent-1.6.0.tar.gz", hash = "sha256:2a906f31ddeb549a61ffe99841397be7aa51984e769258088723713b9403e194"},
 ]
 
 [package.dependencies]
@@ -29,7 +29,7 @@ did-peer-4 = ">=0.1.4,<0.2.0"
 did-webvh = ">=1.0.0"
 indy-credx = ">=1.1.1,<1.2.0"
 indy-vdr = ">=0.4.0,<0.5.0"
-jsonpath-ng = ">=1.7.0,<2.0.0"
+jsonpath-ng = ">=1.8.0,<2.0.0"
 Markdown = ">=3.7,<3.11"
 markupsafe = ">=3.0.2,<4.0.0"
 marshmallow = ">=3.26.1,<3.27.0"
@@ -39,14 +39,14 @@ portalocker = ">=3.1.1,<4.0.0"
 prompt_toolkit = ">=3.0,<3.1"
 psycopg = {version = ">=3.2.1,<4.0.0", extras = ["binary", "pool"]}
 pydid = ">=0.5.1,<0.6.0"
-pyjwt = ">=2.10.1,<2.12.0"
+pyjwt = ">=2.10.1,<2.13.0"
 pyld = ">=2.0.4,<3.0.0"
 pynacl = ">=1.5,<1.7"
 python-dateutil = ">=2.9.0,<3.0.0"
 python-json-logger = ">=3.2.1,<4.0.0"
 pyyaml = ">=6.0.2,<6.1.0"
 qrcode = {version = ">=8.1,<9.0", extras = ["pil"]}
-requests = ">=2.32.3,<2.33.0"
+requests = ">=2.32.3,<2.34.0"
 rlp = ">=4.1.0,<5.0.0"
 sd-jwt = ">=0.10.3,<0.11.0"
 unflatten = ">=0.2,<0.3"
@@ -1471,20 +1471,16 @@ files = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"aca-py\""
 files = [
-    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
-    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
-    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+    {file = "jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138"},
+    {file = "jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3"},
 ]
-
-[package.dependencies]
-ply = "*"
 
 [[package]]
 name = "jwcrypto"
@@ -2062,19 +2058,6 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "ply"
-version = "3.11"
-description = "Python Lex & Yacc"
-optional = true
-python-versions = "*"
-groups = ["main"]
-markers = "extra == \"aca-py\""
-files = [
-    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
-    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
-]
 
 [[package]]
 name = "portalocker"
@@ -3298,4 +3281,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "70e0632b09649f4a4e6407274b02bdfc942941d3514a018739363b85f477f382"
+content-hash = "fe9042875471e31223f53800d4dfe63f424b34764e55631dacfc38e1aa2999d1"

--- a/webvh/pyproject.toml
+++ b/webvh/pyproject.toml
@@ -13,7 +13,7 @@ aiohttp-cors = ">=0.8.1"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = ">=1.5.1,<1.6", optional = true }
+acapy-agent = { version = "~1.6.0", optional = true }
 
 did-webvh = "1.0.0"
 jcs = "^0.2.1"


### PR DESCRIPTION
## ACA-Py Release 1.6.0

| Plugin Name | Supported ACA-Py Release |
| --- | --- |
|basicmessage_storage | 1.6.0|
|cache_redis | 1.6.0|
|cheqd | 1.6.0|
|connection_update | 1.6.0|
|connections | 1.6.0|
|issue_credential | 1.6.0|
|firebase_push_notifications | 1.6.0|
|hedera | 1.6.0|
|multitenant_provider | 1.6.0|
|oid4vc | 1.6.0|
|present_proof | 1.6.0|
|redis_events | 1.6.0|
|rpc | 1.6.0|
|status_list | 1.6.0|

### Plugins Upgraded For ACA-Py Release 1.6.0
 - basicmessage_storage
 - cache_redis
 - cheqd
 - connection_update
 - connections
 - issue_credential
 - firebase_push_notifications
 - hedera
 - multitenant_provider
 - oid4vc
 - present_proof
 - redis_events
 - rpc
 - status_list