### PR TITLE
make file_path optional, use config defaults for list/shard size, reduce log noise, azure file permission fix

### DIFF
--- a/status_list/status_list/v1_0/config.py
+++ b/status_list/status_list/v1_0/config.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from os import getenv
+from typing import Optional
 
 from acapy_agent.config.base import BaseSettings
 from acapy_agent.config.settings import Settings
@@ -31,7 +32,7 @@ class Config:
     list_size: int
     shard_size: int
     public_uri: str
-    file_path: str
+    file_path: Optional[str]
 
     @classmethod
     def from_settings(cls, settings: BaseSettings) -> "Config":
@@ -57,7 +58,5 @@ class Config:
             raise ConfigError("shard_size", "STATUS_LIST_SHARD_SIZE")
         if not public_uri:
             raise ConfigError("public_uri", "STATUS_LIST_PUBLIC_URI")
-        if not file_path:
-            raise ConfigError("file_path", "STATUS_LIST_FILE_PATH")
 
-        return cls(list_size, shard_size, public_uri, file_path)
+        return cls(list_size, shard_size, public_uri, file_path or None)

--- a/status_list/status_list/v1_0/controllers/status_list_def.py
+++ b/status_list/status_list/v1_0/controllers/status_list_def.py
@@ -20,6 +20,7 @@ from aiohttp_apispec import (
 from marshmallow import fields
 from marshmallow.validate import OneOf
 
+from ..config import Config
 from ..error import StatusListError
 from ..models import StatusListDef, StatusListDefSchema, StatusListShard, StatusListCred
 from .. import status_handler
@@ -149,7 +150,14 @@ async def create_status_list_def(request: web.BaseRequest):
 
     try:
         context: AdminRequestContext = request["context"]
+        config = Config.from_settings(context.profile.settings)
         wallet_id = status_handler.get_wallet_id(context)
+
+        # Use config values as defaults when not specified in request body
+        if not list_size:
+            list_size = config.list_size
+        if not shard_size:
+            shard_size = config.shard_size
 
         async with context.profile.transaction() as txn:
             # Create status list definition

--- a/status_list/status_list/v1_0/controllers/status_list_pub.py
+++ b/status_list/status_list/v1_0/controllers/status_list_pub.py
@@ -60,6 +60,12 @@ async def publish_status_list(request: web.BaseRequest):
         published = []
         context: AdminRequestContext = request["context"]
         config = Config.from_settings(context.profile.settings)
+
+        if config.file_path is None:
+            raise web.HTTPBadRequest(
+                reason="Publishing is disabled: file_path is not configured"
+            )
+
         wallet_id = status_handler.get_wallet_id(context)
         async with context.profile.session() as session:
             definition = await StatusListDef.retrieve_by_id(session, definition_id)

--- a/status_list/status_list/v1_0/status_handler.py
+++ b/status_list/status_list/v1_0/status_handler.py
@@ -4,10 +4,8 @@ import gzip
 import logging
 import math
 import os
-import queue
 import shutil
 import tempfile
-import threading
 import time
 import zlib
 from datetime import datetime, timedelta, timezone
@@ -21,7 +19,6 @@ from acapy_agent.core.profile import ProfileSession
 from acapy_agent.storage.error import StorageNotFoundError
 from acapy_agent.wallet.util import bytes_to_b64, unpad
 from bitarray import bitarray
-from filelock import FileLock, Timeout
 
 from .config import Config
 from .error import StatusListError
@@ -29,24 +26,6 @@ from .jwt import jwt_sign
 from .models import StatusListCred, StatusListDef, StatusListReg, StatusListShard
 
 LOGGER = logging.getLogger(__name__)
-
-delete_queue = queue.Queue()
-
-
-def deletion_worker():
-    """Worker thread to handle file deletions."""
-    while True:
-        file_path, delay = delete_queue.get()
-        if delay > 0:
-            time.sleep(delay)
-        try:
-            Path(file_path).unlink()
-        except Exception:
-            pass
-        delete_queue.task_done()
-
-
-threading.Thread(target=deletion_worker, daemon=True).start()
 
 
 def with_retries(max_attempts: int = 3, delay: float = 2.0):
@@ -69,15 +48,6 @@ def with_retries(max_attempts: int = 3, delay: float = 2.0):
     return decorator
 
 
-def alt_name(p: Path) -> Path:
-    """Return alternative file name: 'a.txt' -> 'a.alt.txt', 'foo' -> 'foo.alt'."""
-    return (
-        p.with_name(f"{p.stem}.alt{''.join(p.suffixes)}")
-        if p.suffixes
-        else p.with_name(p.name + ".alt")
-    )
-
-
 def unlink_file(file_path: Path | str | None, delay_seconds: int = 0) -> None:
     """Unlink a file with an optional delay (best-effort)."""
     if not file_path:
@@ -96,47 +66,30 @@ def unlink_file(file_path: Path | str | None, delay_seconds: int = 0) -> None:
 def write_to_file(
     path: str | Path,
     data: bytes | bytearray | memoryview,
-    with_alt: bool = False,
 ) -> None:
-    """Atomically write `data` to `path`; optionally publish an atomic `.alt` sibling."""
+    """Write `data` to `path`.
+
+    Writes to a local temp file first, then copies to the destination.
+    Compatible with both local and network/SMB filesystems (e.g. Azure Files).
+    The target file is set to 0644 so nginx (or any other reader) can serve it.
+    """
     full_path = Path(path).absolute()
     full_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = full_path.with_suffix(full_path.suffix + ".lock")
-    alt_path: Path | None = None
-    alt_temp: Path | None = None
-    temp_path: Path | None = None
-    LOGGER.debug(f"Writing to local file: {full_path}")
+    LOGGER.debug(f"Writing to file: {full_path}")
 
+    tmp_local: Path | None = None
     try:
-        with FileLock(str(lock_path), timeout=10):
-            with tempfile.NamedTemporaryFile(dir=full_path.parent, delete=False) as tmp:
-                tmp.write(memoryview(data))
-                tmp.flush()
-                os.fsync(tmp.fileno())
-                temp_path = Path(tmp.name)
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(memoryview(data))
+            tmp.flush()
+            os.fsync(tmp.fileno())
+            tmp_local = Path(tmp.name)
 
-            if with_alt:
-                alt_path = alt_name(full_path)
-                alt_temp = alt_path.with_suffix(alt_path.suffix + ".tmp")
-                shutil.copy(temp_path, alt_temp)
-                with open(alt_temp, "rb", buffering=0) as f:
-                    os.fsync(f.fileno())
-                os.replace(alt_temp, alt_path)
-
-            os.replace(temp_path, full_path)
-            LOGGER.debug("Write to local file completed.")
-
-    except (OSError, Timeout) as e:
-        LOGGER.error(f"Failed to write to file {full_path}: {e}")
-        raise
+        shutil.copy2(tmp_local, full_path)
+        full_path.chmod(0o644)
+        LOGGER.debug(f"Write to {full_path} completed.")
     finally:
-        unlink_file(temp_path)
-        unlink_file(lock_path)
-        if with_alt:
-            unlink_file(alt_temp)
-            # Instead of spawning a thread per file, use the queue
-            if alt_path:
-                delete_queue.put((alt_path, 5))
+        unlink_file(tmp_local)
 
 
 def get_wallet_id(context: AdminRequestContext):

--- a/status_list/status_list/v1_0/status_handler.py
+++ b/status_list/status_list/v1_0/status_handler.py
@@ -362,12 +362,16 @@ async def update_status_list_entry(
     shard.status_bits = status_bits
     await shard.save(session, reason="Update status list entry.")
 
-    # Emit event
     shard.state = "updated"
     payload = shard.serialize()
     payload["credential_id"] = credential_id
     payload["list_index"] = entry_index
     payload["status"] = bitstring
+    # Log and remove large bitstring data from payload before emitting event
+    LOGGER.debug("Shard event payload: %s", payload)
+    payload.pop("status_encoded", None)
+    payload.pop("mask_encoded", None)
+    # Emit event
     await shard.emit_event(session, payload)
 
     return {

--- a/status_list/status_list/v1_0/tests/test_config.py
+++ b/status_list/status_list/v1_0/tests/test_config.py
@@ -41,7 +41,5 @@ async def test_config(plugin_settings: dict):
 
     copied_settings = deepcopy(plugin_settings)
     del copied_settings[PLUGIN_CONFIG_KEY]["status_list"]["file_path"]
-    try:
-        Config.from_settings(Settings(copied_settings))
-    except ConfigError as error:
-        assert error
+    config = Config.from_settings(Settings(copied_settings))
+    assert config.file_path is None

--- a/status_list/status_list/v1_0/tests/test_status_handler.py
+++ b/status_list/status_list/v1_0/tests/test_status_handler.py
@@ -1,8 +1,8 @@
 import pytest
 import os
+import shutil
 from bitarray import util as bitutil
 from unittest.mock import MagicMock, Mock, patch
-from filelock import Timeout
 
 from acapy_agent.admin.request_context import AdminRequestContext
 
@@ -64,47 +64,32 @@ def test_write_to_file_success(tmp_path):
     assert file_path.exists()
     assert file_path.read_bytes() == content
 
+    # Test retry: patch shutil.copy2 to fail once then succeed
     file_path = tmp_path / "test_retry.txt"
     content = b"retry test"
-
-    # Patch os.replace to fail once then succeed
     call_tracker = {"count": 0}
+    original_copy2 = shutil.copy2
 
-    def flaky_replace(src, dst):
+    def flaky_copy2(src, dst, **kwargs):
         if call_tracker["count"] == 0:
             call_tracker["count"] += 1
             raise OSError("Simulated failure")
-        return original_replace(src, dst)
+        return original_copy2(src, dst, **kwargs)
 
-    original_replace = os.replace
-
-    with patch("status_list.v1_0.status_handler.os.replace", side_effect=flaky_replace):
+    with patch("status_list.v1_0.status_handler.shutil.copy2", side_effect=flaky_copy2):
         status_handler.write_to_file(str(file_path), content)
 
     assert file_path.exists()
     assert file_path.read_bytes() == content
 
+    # When shutil.copy2 always fails, write_to_file raises
     file_path = tmp_path / "fail.txt"
     content = b"should fail"
 
-    # Patch os.replace to always raise
     with patch(
-        "status_list.v1_0.status_handler.os.replace", side_effect=OSError("always fail")
+        "status_list.v1_0.status_handler.shutil.copy2", side_effect=OSError("always fail")
     ):
         with pytest.raises(OSError, match="always fail"):
-            status_handler.write_to_file(str(file_path), content)
-
-    # Final file should not exist
-    assert not file_path.exists()
-
-    file_path = tmp_path / "locked.txt"
-    content = b"locked"
-
-    # Patch FileLock to raise Timeout
-    with patch(
-        "status_list.v1_0.status_handler.FileLock", side_effect=Timeout("lock timeout")
-    ):
-        with pytest.raises(Timeout, match="lock timeout"):
             status_handler.write_to_file(str(file_path), content)
 
     assert not file_path.exists()

--- a/status_list/status_list/v1_0/tests/test_status_handler.py
+++ b/status_list/status_list/v1_0/tests/test_status_handler.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 import shutil
 from bitarray import util as bitutil
 from unittest.mock import MagicMock, Mock, patch


### PR DESCRIPTION
- Make file_path config optional; disable publishing when unset
- Use plugin settings/env as defaults for list_size and shard_size
  when not specified in create request body
- Strip encoded list fields from shard event payloads (log at debug level)
- Fix permission issue when publishing to Azure Files