### PR TITLE
Remove isbang/compase-action as not needed

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -219,12 +219,15 @@ jobs:
           done
           echo unit_test_plugins=${failed_plugins[*]} >> $GITHUB_OUTPUT
       # ----------------------------------------------
+<<<<<<< Updated upstream
       #       Install docker compose
       # ----------------------------------------------
       - name: Initialize Docker Compose
         if: ${{ steps.upgrade_available.outputs.available == 'true' && github.event.inputs.re_release != 'true'}} 
         uses: isbang/compose-action@v1.5.1
       # ----------------------------------------------
+=======
+>>>>>>> Stashed changes
       #       Collect plugins that fail integration tests
       # ----------------------------------------------
       - name: Integration Test Plugins

--- a/.github/workflows/pr-integration-tests.yaml
+++ b/.github/workflows/pr-integration-tests.yaml
@@ -21,11 +21,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
       #----------------------------------------------
+<<<<<<< Updated upstream
       #       Get docker compose
       #----------------------------------------------
       - name: Initialize Docker Compose
         uses: isbang/compose-action@v1.5.1
       #----------------------------------------------
+=======
+>>>>>>> Stashed changes
       #       Get changed files
       #----------------------------------------------
       - name: Get changed files


### PR DESCRIPTION
Per Copilot and Claude:

The Initialize Docker Compose step in the two workflow files listed below was not doing anything useful. It used isbang/compose-action with no configuration, so it looked for a docker-compose.yaml at the repo root — which doesn't exist. All the actual docker compose commands run directly in run: steps, each pointed at the relevant plugin's integration/ directory.

docker compose v2 is already available on ubuntu-latest runners, so no setup step is needed.

The Dependabot bump from v1.5.1 to v3.0.0 broke CI because v3 fails when there's no root compose file as we (don’t have) in this repo. Rather than update to a version that fails in a new way, the step is just removed.

Files changed:

- .github/workflows/pr-integration-tests.yaml
- .github/workflows/create-release-pr.yaml


Signed-off-by: Stephen Curran <swcurran@gmail.com>
