### PR TITLE
fix: update frontend Dockerfile

### DIFF
--- a/oid4vc/demo/frontend/Dockerfile
+++ b/oid4vc/demo/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 WORKDIR /app
 
 # Install jq for JSON parsing in entrypoint.sh

--- a/oid4vc/demo/frontend/Dockerfile
+++ b/oid4vc/demo/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 WORKDIR /app
 
 # Install jq for JSON parsing in entrypoint.sh


### PR DESCRIPTION
Just fixing the oid4vc demo. The frontend after the libs updates now requires node 20 instead of 18