### PR TITLE
Update pyproject.toml files to have consistent uvicorn version strings

### DIFF
--- a/oid4vc/auth_server/poetry.lock
+++ b/oid4vc/auth_server/poetry.lock
@@ -1956,4 +1956,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "2e26ac769cc8b937a44b06d745ab2a4780b134cfca3955d09225062c592591c9"
+content-hash = "661e84000a7b65b4f40d7f078988f199b2d4ef81725205469644ad4ab5e88803"

--- a/oid4vc/auth_server/pyproject.toml
+++ b/oid4vc/auth_server/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{ include = "admin" }, { include = "tenant" }, { include = "core" }]
 python = "^3.13"
 orjson = "^3.11.6"
 fastapi = "^0.116"
-uvicorn = { extras = ["standard"], version = "^0.35" }
+uvicorn = { extras = ["standard"], version = ">=0.35,<0.51" }
 authlib = "^1.6"
 SQLAlchemy = { version = "^2.0", extras = ["asyncio"] }
 asyncpg = "^0.30"

--- a/redis_events/integration/poetry.lock
+++ b/redis_events/integration/poetry.lock
@@ -1267,4 +1267,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "8ba0f46b22fde79e38117df9a755816691ba3d12e81092b2a41d862b55227bbf"
+content-hash = "6e8c92c873313aa5b0c3a4c9632b7b792f682caf62e3ab00868e3fb9fedccec8"

--- a/redis_events/integration/pyproject.toml
+++ b/redis_events/integration/pyproject.toml
@@ -14,7 +14,7 @@ aiohttp = "^3.13.3"
 fastapi-slim = "^0.128.0"
 nest-asyncio = "^1.5.5"
 redis = "^5.1.1"
-uvicorn = ">=0.38,<0.51"
+uvicorn = ">=0.35,<0.51"
 pydantic = "2.12.5"
 
 [tool.poetry.group.dev.dependencies]

--- a/redis_events/poetry.lock
+++ b/redis_events/poetry.lock
@@ -3386,4 +3386,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "0cb1214127d450e883ac854437a147b23010fad72325a9472b0ef55fe6943e46"
+content-hash = "c7016a7d7e564ccc0b4b87d21b9505ea12df21886dc72705eb9dc8d3a45d6eb0"

--- a/redis_events/pyproject.toml
+++ b/redis_events/pyproject.toml
@@ -13,7 +13,7 @@ acapy-agent = { version = "~1.6.0", optional = true }
 aiohttp = "^3.13.3"
 fastapi-slim = "^0.128.0"
 redis = "^5.2.1"
-uvicorn = "^0.50.2"
+uvicorn = ">=0.35,<0.51"
 pydantic = "^2.12.5"
 
 [tool.poetry.extras]


### PR DESCRIPTION
Per discussion in last Weekly Update PR #3273, updating the pyproject.toml version strings to be the same across all plugins.

This should also close the new uvicorn related dependabot PRs that remain open.



Signed-off-by: Stephen Curran <swcurran@gmail.com>
