### PR TITLE
Plugins Release PR for ACA-Py 1.6.1

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,41 @@
 
 > **Note:** Release notes are also published as [GitHub Releases](https://github.com/openwallet-foundation/acapy-plugins/releases). This file may be phased out in favor of the CHANGELOG and release tags; feedback welcome.
 
+## ACA-Py Release 1.6.1
+
+| Plugin Name | Supported ACA-Py Release |
+| --- | --- |
+|basicmessage_storage | 1.6.1|
+|cache_redis | 1.6.1|
+|cheqd | 1.6.1|
+|connection_update | 1.6.1|
+|connections | 1.6.1|
+|issue_credential | 1.6.1|
+|firebase_push_notifications | 1.6.1|
+|hedera | 1.6.1|
+|multitenant_provider | 1.6.1|
+|oid4vc | 1.6.1|
+|present_proof | 1.6.1|
+|redis_events | 1.6.1|
+|rpc | 1.6.1|
+|status_list | 1.6.1|
+
+### Plugins Upgraded For ACA-Py Release 1.6.1
+ - basicmessage_storage
+ - cache_redis
+ - cheqd
+ - connection_update
+ - connections
+ - issue_credential
+ - firebase_push_notifications
+ - hedera
+ - multitenant_provider
+ - oid4vc
+ - present_proof
+ - redis_events
+ - rpc
+ - status_list
+
 ## ACA-Py Release 1.6.0
 
 | Plugin Name | Supported ACA-Py Release |

--- a/basicmessage_storage/poetry.lock
+++ b/basicmessage_storage/poetry.lock
@@ -3076,4 +3076,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "eaad71577a298d78fa792278e416770941cb94afcc94c37fede0f4fdaf9b4252"
+content-hash = "3aeb79a7459fd828e5053130b75b14bc22c4c0514017f40cb4eac4ea48a47f12"

--- a/basicmessage_storage/pyproject.toml
+++ b/basicmessage_storage/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 mergedeep = "^1.3.4"
 

--- a/cache_redis/poetry.lock
+++ b/cache_redis/poetry.lock
@@ -3389,4 +3389,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "b46e4920672d92017375a40f64e6f56a2c83ae151f7c592eaa5faea744a26a3a"
+content-hash = "7665cc346fe91904f3559a71b8b901e4e371198a239d393738b718ccfa585c8d"

--- a/cache_redis/pyproject.toml
+++ b/cache_redis/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Colton Wolkins <colton@indicio.tech>", "Kim Ebert <kim@indicio.tech>
 
 [tool.poetry.dependencies]
 python = "^3.13"
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 redis = "^4.3.0"
 
 # Define ACA-Py as an optional/extra dependency so it can be

--- a/cheqd/poetry.lock
+++ b/cheqd/poetry.lock
@@ -3079,4 +3079,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "5e71684d2a499fddf156063709770ae21a0fa44b5779d6641a779d9528ce174e"
+content-hash = "ddd05e14218f3545505210c224139fd2f8d4108fa877da49e788b06a55c70c28"

--- a/cheqd/pyproject.toml
+++ b/cheqd/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 cryptography = "<51.0.0"
 

--- a/connection_update/poetry.lock
+++ b/connection_update/poetry.lock
@@ -3064,4 +3064,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "a5bc56137c4337e20e4784ac32d2a28dc0c71aaa97234811ca308ab6f30a7df7"
+content-hash = "45dfdd4eb8249f417a83e67828c8a8028823a5c2a140dd985fbb935c09e2961c"

--- a/connection_update/pyproject.toml
+++ b/connection_update/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 
 [tool.poetry.extras]

--- a/connections/poetry.lock
+++ b/connections/poetry.lock
@@ -3064,4 +3064,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "a5bc56137c4337e20e4784ac32d2a28dc0c71aaa97234811ca308ab6f30a7df7"
+content-hash = "45dfdd4eb8249f417a83e67828c8a8028823a5c2a140dd985fbb935c09e2961c"

--- a/connections/pyproject.toml
+++ b/connections/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 
 [tool.poetry.extras]

--- a/firebase_push_notifications/poetry.lock
+++ b/firebase_push_notifications/poetry.lock
@@ -3273,4 +3273,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "1103c00db0694631785a4179e53ae5f9df461cee8a2aca3c8eae1e9cfc093467"
+content-hash = "b936ddcfc92d34c2d0ae83dd1c51cc88bde66a7d40d3a7c9a2d828fa9751b330"

--- a/firebase_push_notifications/pyproject.toml
+++ b/firebase_push_notifications/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 marshmallow = "^3.23.3"
 google-auth = "^2.49.1"

--- a/hedera/poetry.lock
+++ b/hedera/poetry.lock
@@ -3568,4 +3568,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "5356c7f051053dbe50310531986abbfc869f6ab8262efa6ace6ea957d8f718c8"
+content-hash = "5efb65f941fb445add8d43d32039e35b492ab94a3f9084daa065a95505192985"

--- a/hedera/pyproject.toml
+++ b/hedera/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 hiero-did-sdk-python = "0.1.6"
 

--- a/issue_credential/poetry.lock
+++ b/issue_credential/poetry.lock
@@ -3342,4 +3342,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "489ccf9037f5e2e8e68422ea9ad6ca7f7d55adf6aadca0635c18b02d384681c8"
+content-hash = "737b80de9df61e43233bd1312b89a3570282287ef5f26b43dc285c6c5cd7d98d"

--- a/issue_credential/pyproject.toml
+++ b/issue_credential/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 present-proof = { git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "present_proof" }
 
 

--- a/multitenant_provider/poetry.lock
+++ b/multitenant_provider/poetry.lock
@@ -3151,4 +3151,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "6926dc92f1c9ddc562bdf7609f79db012204fc307a7a64dc516608321f953571"
+content-hash = "c1befdbd8291c6a615ff6193fcf467b6bf51943c7a082e2ad6329eb7f60f9be3"

--- a/multitenant_provider/pyproject.toml
+++ b/multitenant_provider/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 bcrypt = "^5.0.0"
 mergedeep = "^1.3.4"

--- a/oid4vc/poetry.lock
+++ b/oid4vc/poetry.lock
@@ -3754,4 +3754,4 @@ sd-jwt-vc = ["jsonpointer"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "84e2ea974272fcd6fc31da408b0a0896647822a4503bbdb21e74d520e7bcd4f0"
+content-hash = "13a5b375ddcc9c006db4ab56d54da4d3b5ce577cee17f82de6d9ff72e7b4f3e1"

--- a/oid4vc/pyproject.toml
+++ b/oid4vc/pyproject.toml
@@ -22,7 +22,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 aiohttp = "^3.13.3"
 aries-askar = "~0.5.0"

--- a/plugin_globals/poetry.lock
+++ b/plugin_globals/poetry.lock
@@ -3064,4 +3064,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "a5bc56137c4337e20e4784ac32d2a28dc0c71aaa97234811ca308ab6f30a7df7"
+content-hash = "45dfdd4eb8249f417a83e67828c8a8028823a5c2a140dd985fbb935c09e2961c"

--- a/plugin_globals/pyproject.toml
+++ b/plugin_globals/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 
 [tool.poetry.extras]

--- a/present_proof/poetry.lock
+++ b/present_proof/poetry.lock
@@ -3461,4 +3461,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "b88ca0553b8a207dc9ba4aca22bbaf649ff0ed1eeaa77b1cb794abcf2788c0f2"
+content-hash = "7f8d1e7b176f552b7fda8ba25ae364cc21cd3eb33579667fddafb354fe3cfd59"

--- a/present_proof/pyproject.toml
+++ b/present_proof/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 issue-credential = { git = "https://github.com/openwallet-foundation/acapy-plugins.git", branch = "main", subdirectory = "issue_credential" }
 
 

--- a/redis_events/poetry.lock
+++ b/redis_events/poetry.lock
@@ -3378,4 +3378,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "60079ee9bd278f288220e37b4cc1b83ad8d1c40be2cdf0ae0fe37eb46574ec40"
+content-hash = "ee3053f600571ccc8a522780a46de91aa26aecc80cbe14ee3a2cfd600b35bcc8"

--- a/redis_events/pyproject.toml
+++ b/redis_events/pyproject.toml
@@ -8,7 +8,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 aiohttp = "^3.13.3"
 fastapi-slim = "^0.128.0"

--- a/rpc/poetry.lock
+++ b/rpc/poetry.lock
@@ -3064,4 +3064,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "a5bc56137c4337e20e4784ac32d2a28dc0c71aaa97234811ca308ab6f30a7df7"
+content-hash = "45dfdd4eb8249f417a83e67828c8a8028823a5c2a140dd985fbb935c09e2961c"

--- a/rpc/pyproject.toml
+++ b/rpc/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 
 [tool.poetry.extras]

--- a/status_list/poetry.lock
+++ b/status_list/poetry.lock
@@ -3220,4 +3220,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "bee76aa248c2677f1ef39a50794636ec44d0a47f19eac160116a8c7fb951ad81"
+content-hash = "1bb90d3d2a4eec4f36a13de984036f15da40025c20043e42a58093c884d7a0e3"

--- a/status_list/pyproject.toml
+++ b/status_list/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.13"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 bitarray = "^3.0.0"
 filelock = "^3.25.2"

--- a/webvh/poetry.lock
+++ b/webvh/poetry.lock
@@ -3260,4 +3260,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "e27b8e86da12f14cf4b30ef58a309d86987c0ea55b56c7350bb89df45c31ad01"
+content-hash = "e38f7afbc1db49a23496ce3bb59b06792ee8aaea2f5d48661fe0394a676c8b59"

--- a/webvh/pyproject.toml
+++ b/webvh/pyproject.toml
@@ -13,7 +13,7 @@ aiohttp-cors = ">=0.8.1"
 
 # Define ACA-Py as an optional/extra dependency so it can be
 # explicitly installed with the plugin if desired.
-acapy-agent = { version = "~1.6.0", optional = true }
+acapy-agent = { version = "~1.6.1", optional = true }
 
 did-webvh = "1.0.1"
 jcs = "^0.2.1"


### PR DESCRIPTION
PR manually created to update the Plugins for ACA-Py Release 1.6.1.

Process was:

- Search and replace all instances of `acapy-agent = { version = "~1.6.0", optional = true }` to 1.6.1
  - Found 16 instances in 16 pyproject.toml files.
  - That matches the expectations from the Plugin Release PR for 1.6.0 #2919
- Run `python repo_manager.py 6` to update all poetry lock files -- updated the 16 lock files associated with the pyproject.toml files.
- Copy/paste 1.6.0 section of RELEASES.md and update all references to 1.6.1

@jamshale -- anything to be done after this runs?
